### PR TITLE
anticipate image download for next questions

### DIFF
--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -24,14 +24,14 @@ const getImagesUrls = (images, barcode) => {
   const formattedCode = offService.getFormatedBarcode(barcode);
   const rootImageUrl = offService.getImageUrl(formattedCode);
   return Object.keys(images)
-    .filter((key) => key)
+    .filter((key) => !isNaN(key))
     .map((key) => `${rootImageUrl}/${key}.jpg`);
 };
 
 const ProductInformation = ({ question }) => {
   const { t } = useTranslation();
   const [productData, setProductData] = React.useState({});
-  const [hideImages, setHideImages] = React.useState(false);
+  const [hideImages, setHideImages] = React.useState(true);
 
   React.useEffect(() => {
     if (!question?.barcode) {

--- a/src/pages/questions/index.jsx
+++ b/src/pages/questions/index.jsx
@@ -42,6 +42,18 @@ export default function Questions() {
       <Grid item sm={12} md={2}>
         <UserData remainingQuestionNb={remainingQuestionNb} answers={answers} />
       </Grid>
+      {/* pre-fetch images of the next question */}
+      {buffer
+        .slice(1, 5)
+        .map((q) =>
+          q.source_image_url ? (
+            <link
+              rel="prefetch"
+              key={q.source_image_url}
+              href={q.source_image_url}
+            />
+          ) : null
+        )}
     </Grid>
   );
 }


### PR DESCRIPTION
When we display the question of index 0 in the buffer, we also ask the browser to fetch images with indexes 1, 2, 3, 4

such that time between two question display is reduced