### PR TITLE
fix: countries list was a single long string which caused the list to…

### DIFF
--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -28,6 +28,19 @@ const getImagesUrls = (images, barcode) => {
     .map((key) => `${rootImageUrl}/${key}.jpg`);
 };
 
+
+const formatStringArray = (stringArray) => {
+  if (stringArray.length === 0) return ''
+
+  let result = stringArray[0];
+
+  for(let i = 0; i < stringArray.length; i++) {
+    result += ', ' + stringArray[i]
+  }
+
+  return result + '.';
+}
+
 const ProductInformation = ({ question }) => {
   const { t } = useTranslation();
   const [productData, setProductData] = React.useState({});
@@ -132,7 +145,7 @@ const ProductInformation = ({ question }) => {
         {t("questions.ingredients")}: {productData?.ingredientsText}
       </p>
       <p>
-        {t("questions.countries")}: {productData?.countriesTags}
+        {t("questions.countries")}: {!productData?.countriesTags?null:formatStringArray(productData.countriesTags)}
       </p>
       <Divider />
     </Box>


### PR DESCRIPTION
Countries list  wrapped

### What
- countries list was a single long string causing that it never or rarely wrapped, affecting the width of the countries <p>, specially when a long list 
- formatted the list, addded commas and space between the elements of the list
### Screenshot
<img width="547" alt="imagen" src="https://user-images.githubusercontent.com/12853324/181113874-827e1ce9-2413-4314-9b2b-d3d57a7df5b4.png">

