### PR TITLE
fix: link to home page use react-router

### DIFF
--- a/src/components/ResponsiveAppBar.jsx
+++ b/src/components/ResponsiveAppBar.jsx
@@ -115,8 +115,8 @@ const ResponsiveAppBar = () => {
             <Typography
               variant="h5"
               noWrap
-              component="a"
-              href=""
+              component={Link}
+              to="/"
               sx={{
                 flexGrow: 0,
                 fontFamily: "monospace",
@@ -163,8 +163,8 @@ const ResponsiveAppBar = () => {
               <Typography
                 variant="h6"
                 noWrap
-                component="a"
-                href="/"
+                component={Link}
+                to="/"
                 sx={{
                   mr: 2,
                   fontFamily: "monospace",


### PR DESCRIPTION
When clicking on "Hunger Games" in the header you stay in the same page instead of going to the home page

Now you  go to the home page 
