### PR TITLE
feat: logo game improvement

### DIFF
--- a/src/components/LogoForm.jsx
+++ b/src/components/LogoForm.jsx
@@ -56,7 +56,7 @@ const LogoForm = (props) => {
 
   const send = React.useCallback(async () => {
     setIsSending(true);
-    request(getFormattedValues({ type: innerType, value: innerValue }));
+    await request(getFormattedValues({ type: innerType, value: innerValue }));
     setIsSending(false);
   }, [request, innerType, innerValue]);
 

--- a/src/components/LogoForm.jsx
+++ b/src/components/LogoForm.jsx
@@ -72,13 +72,6 @@ const LogoForm = (props) => {
       {...other}
     >
       <TextField
-        value={innerValue}
-        onChange={(event) => setInnerValue(event.target.value)}
-        label={t("logos.value")}
-        sx={{ minWidth: { xs: "80%", sm: 350 } }}
-        size="small"
-      />
-      <TextField
         value={innerType}
         onChange={(event) => setInnerType(event.target.value)}
         select
@@ -92,6 +85,13 @@ const LogoForm = (props) => {
           </MenuItem>
         ))}
       </TextField>
+      <TextField
+        value={innerValue}
+        onChange={(event) => setInnerValue(event.target.value)}
+        label={t("logos.value")}
+        sx={{ minWidth: { xs: "80%", sm: 350 } }}
+        size="small"
+      />
       <LoadingButton
         onClick={send}
         loading={isSending}


### PR DESCRIPTION
### What
Fix #140
Fix #137

### New behavior:
- When sending the annotation, button shows a loading animation
- After annotation is sent to the server, the selected logos are unselected
- new button action
	- select all
	- unselect all
	- refresh
- when the URL has the `logo_id` search parameter, the corresponding logo is always focused, and the value/type is filled with its value if already annotated

### Remaining

When the `logo_id` is set, refresh should lead to a new page, because refreshing with same search params leads to the same page

![image](https://user-images.githubusercontent.com/45398769/184475867-18b0ad0e-167e-4885-8ea3-3313d55bd983.png)