### PR TITLE
show logged in status in app bar on desktop

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import DevModeContext from "./contexts/devMode";
 import { getIsDevMode, getVisiblePages } from "./localeStorageManager";
 import LoginContext from "./contexts/login";
 import off from "./off";
+import { IS_DEVELOPMENT_MODE } from "./const";
 
 export default function App() {
   const [devMode, setDevMode] = React.useState(getIsDevMode);
@@ -82,7 +83,9 @@ export default function App() {
   const { trackPageView } = useMatomo();
 
   React.useEffect(() => {
-    trackPageView();
+    if (!IS_DEVELOPMENT_MODE) {
+      trackPageView();
+    }
   }, [location, trackPageView]);
 
   return (

--- a/src/components/ResponsiveAppBar.jsx
+++ b/src/components/ResponsiveAppBar.jsx
@@ -10,6 +10,7 @@ import Container from "@mui/material/Container";
 import Button from "@mui/material/Button";
 import MenuItem from "@mui/material/MenuItem";
 import ListSubheader from "@mui/material/ListSubheader";
+import Tooltip from "@mui/material/Tooltip";
 import MuiLink from "@mui/material/Link";
 import SettingsIcon from "@mui/icons-material/Settings";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
@@ -46,7 +47,7 @@ const ResponsiveAppBar = () => {
     setAnchorElNav(null);
   };
 
-  const { isLoggedIn } = React.useContext(LoginContext);
+  const { isLoggedIn, userName } = React.useContext(LoginContext);
   const { devMode: isDevMode, visiblePages } = React.useContext(DevModeContext);
   const displayedPages = pages.filter(
     (page) => !page.devModeOnly || (isDevMode && visiblePages[page.url])
@@ -188,11 +189,7 @@ const ResponsiveAppBar = () => {
                     to={`/${page.url}`}
                     data-welcome-tour={page.url}
                   >
-                    {page.url === "settings" ? (
-                      <SettingsIcon />
-                    ) : (
-                      t(page.translationKey)
-                    )}
+                    {t(page.translationKey)}
                   </Button>
                 ) : null
               )}
@@ -202,9 +199,12 @@ const ResponsiveAppBar = () => {
                 display: "flex",
                 flexDirection: "row",
                 alignItems: "baseline",
+                "&>*": {
+                  mr: 1.5,
+                },
               }}
             >
-              <Button
+              <IconButton
                 color="inherit"
                 onClick={handleCloseNavMenu}
                 sx={{ my: 2 }}
@@ -213,8 +213,13 @@ const ResponsiveAppBar = () => {
                 data-welcome-tour="settings"
               >
                 <SettingsIcon />
-              </Button>
+              </IconButton>
               <Welcome />
+              <Tooltip
+                title={isLoggedIn ? `logged as ${userName}` : `not logged in`}
+              >
+                <AccountCircleIcon color={isLoggedIn ? "success" : "error"} />
+              </Tooltip>
             </Box>
           </Box>
         </Toolbar>

--- a/src/components/welcome/Welcome.jsx
+++ b/src/components/welcome/Welcome.jsx
@@ -1,14 +1,18 @@
-import { Button, Box, Typography } from "@mui/material";
-import React, { useState } from "react";
-import Tour from "reactour";
+import * as React from "react";
+
+import IconButton from "@mui/material/IconButton";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+import Tour from "reactour";
 import {
   localSettings,
   localSettingsKeys,
   getTour,
 } from "../../localeStorageManager";
-import { useTheme } from "@mui/material/styles";
-import useMediaQuery from "@mui/material/useMediaQuery";
 
 const styles = {
   minWidth: "min(90%, 800px)",
@@ -293,7 +297,7 @@ const Welcome = () => {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up("sm"));
 
-  const [isTourOpen, setIsTourOpen] = useState(false);
+  const [isTourOpen, setIsTourOpen] = React.useState(false);
   const handleShowTour = () => {
     setIsTourOpen(false);
     localSettings.update(localSettingsKeys.showTour, false);
@@ -316,7 +320,7 @@ const Welcome = () => {
           handleShowTour();
         }}
       />
-      <Button
+      <IconButton
         color="inherit"
         onClick={() => {
           setIsTourOpen(true);
@@ -324,7 +328,7 @@ const Welcome = () => {
         data-welcome-tour="tour"
       >
         <QuestionMarkIcon />
-      </Button>
+      </IconButton>
     </>
   );
 };


### PR DESCRIPTION
Add logged in information on desktop

![Screenshot from 2022-08-23 21-39-59](https://user-images.githubusercontent.com/45398769/186251963-ae300457-83c3-4286-a60b-03cc79478c09.png)

Remove matomo on dev env (Fix #161)
