### PR TITLE
feat: improve logos UI

### DIFF
--- a/src/components/LogoForm.jsx
+++ b/src/components/LogoForm.jsx
@@ -8,6 +8,8 @@ import LoadingButton from "@mui/lab/LoadingButton";
 
 import { useTranslation } from "react-i18next";
 
+import LabelFilter from "../components/QuestionFilter/LabelFilter";
+
 const TYPE_WITHOUT_VALUE = ["packager_code", "qr_code"];
 
 const logoTypeOptions = [
@@ -85,13 +87,27 @@ const LogoForm = (props) => {
           </MenuItem>
         ))}
       </TextField>
-      <TextField
-        value={innerValue}
-        onChange={(event) => setInnerValue(event.target.value)}
-        label={t("logos.value")}
-        sx={{ minWidth: { xs: "80%", sm: 350 } }}
-        size="small"
-      />
+
+      {["label", "category"].includes(innerType) ? (
+        <LabelFilter
+          showKey
+          value={innerValue}
+          onChange={setInnerValue}
+          insightType={innerType}
+          label={t("logos.value")}
+          size="small"
+          sx={{ minWidth: { xs: "80%", sm: 350 } }}
+        />
+      ) : (
+        <TextField
+          value={innerValue}
+          onChange={(event) => setInnerValue(event.target.value)}
+          label={t("logos.value")}
+          sx={{ minWidth: { xs: "80%", sm: 350 } }}
+          size="small"
+        />
+      )}
+
       <LoadingButton
         onClick={send}
         loading={isSending}

--- a/src/components/LogoSearchForm.jsx
+++ b/src/components/LogoSearchForm.jsx
@@ -7,6 +7,8 @@ import Button from "@mui/material/Button";
 
 import { useTranslation } from "react-i18next";
 
+import LabelFilter from "../components/QuestionFilter/LabelFilter";
+
 const TYPE_WITHOUT_VALUE = ["packager_code", "qr_code"];
 
 const logoTypeOptions = [
@@ -68,13 +70,6 @@ const LogoSearchForm = (props) => {
       <Stack direction={{ xs: "column", sm: "row" }} spacing={1} wrap="wrap">
         <TextField
           fullWidth
-          value={innerValue}
-          onChange={(event) => setInnerValue(event.target.value)}
-          label={t("logos.value")}
-          size="small"
-        />
-        <TextField
-          fullWidth
           value={innerType}
           onChange={(event) => setInnerType(event.target.value)}
           select
@@ -87,6 +82,25 @@ const LogoSearchForm = (props) => {
             </MenuItem>
           ))}
         </TextField>
+        {["label", "category"].includes(innerType) ? (
+          <LabelFilter
+            showKey
+            fullWidth
+            value={innerValue}
+            onChange={setInnerValue}
+            insightType={innerType}
+            label={t("logos.value")}
+            size="small"
+          />
+        ) : (
+          <TextField
+            fullWidth
+            value={innerValue}
+            onChange={(event) => setInnerValue(event.target.value)}
+            label={t("logos.value")}
+            size="small"
+          />
+        )}
       </Stack>
 
       <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>

--- a/src/components/QuestionFilter/LabelFilter.tsx
+++ b/src/components/QuestionFilter/LabelFilter.tsx
@@ -16,7 +16,7 @@ const cleanName = (name) =>
     .replace(/[^0-9a-z]/gi, " ");
 
 const LabelFilter = (props) => {
-  const { onChange, value, insightType, ...other } = props;
+  const { showKey, onChange, value, insightType, fullWidth, ...other } = props;
   const [options, setOptions] = React.useState([]);
   const [innerValue, setInnerValue] = React.useState(null);
   const lang = getLang();
@@ -39,6 +39,7 @@ const LabelFilter = (props) => {
 
   return (
     <Autocomplete
+      fullWidth={fullWidth}
       freeSolo
       onChange={(_, newValue) => {
         setInnerValue(newValue);
@@ -74,7 +75,13 @@ const LabelFilter = (props) => {
       value={innerValue}
       options={options}
       getOptionLabel={(option) => option?.name ?? option}
-      renderInput={(params) => <TextField {...params} {...other} />}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          {...other}
+          helperText={showKey && innerValue?.key}
+        />
+      )}
       filterOptions={(options, state) => {
         return options.filter((option) =>
           option?.cleanName.includes(cleanName(state.inputValue))

--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import Stack from "@mui/material/Stack";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
 import LoadingButton from "@mui/lab/LoadingButton";
 
 import { useTranslation } from "react-i18next";
@@ -343,6 +344,7 @@ export default function LogoAnnotation() {
         }}
         isLoading={logoState.isLoading}
       />
+      {/* Selection buttons */}
       <Stack direction="row" spacing={1} sx={{ my: 1 }}>
         <Button size="small" onClick={selectAll}>
           {t("logos.select_all")}
@@ -367,11 +369,18 @@ export default function LogoAnnotation() {
         </LoadingButton>
       </Stack>
 
+      {logoState.isLoading && (
+        <Box sx={{ width: "100%", textAlign: "center", py: 10 }}>
+          <CircularProgress />
+        </Box>
+      )}
+      {/* Selected logos */}
       <LogoGrid
         logos={logoState.logos.filter((logo) => logo.selected)}
         toggleLogoSelection={toggleSelection}
       />
 
+      {/* Logos to select */}
       <LogoGrid
         logos={logoState.logos}
         toggleLogoSelection={toggleSelection}

--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -7,7 +7,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import LoadingButton from "@mui/lab/LoadingButton";
 
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 
 import robotoff from "../../robotoff";
 import off from "../../off";
@@ -346,10 +346,11 @@ export default function LogoAnnotation() {
       />
       {/* Selection buttons */}
       <Stack direction="row" spacing={1} sx={{ my: 1 }}>
-        <Button size="small" onClick={selectAll}>
+        <Button variant="outlined" size="small" onClick={selectAll}>
           {t("logos.select_all")}
         </Button>
         <Button
+          variant="outlined"
           size="small"
           disabled={
             selectedIds.length === 0 ||
@@ -361,12 +362,23 @@ export default function LogoAnnotation() {
           {t("logos.unselect_all")}
         </Button>
         <LoadingButton
+          variant="outlined"
           size="small"
           onClick={refreshData}
           loading={isRefreshing}
         >
           Refresh
         </LoadingButton>
+        <div style={{ flexGrow: 1 }} />
+        <Button
+          size="small"
+          variant="contained"
+          color="secondary"
+          component={Link}
+          to="/logos/search/"
+        >
+          Search specific logo
+        </Button>
       </Stack>
 
       {logoState.isLoading && (

--- a/src/pages/logos/LogoSearch.jsx
+++ b/src/pages/logos/LogoSearch.jsx
@@ -3,7 +3,7 @@ import LogoGrid from "../../components/LogoGrid";
 import LogoSearchForm from "../../components/LogoSearchForm";
 import robotoff from "../../robotoff";
 import off from "../../off";
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 
 const transformLogo = (logo) => {
   const src =
@@ -64,11 +64,20 @@ export default function LogoSearch() {
 
       <LogoGrid logos={result.logos} toggleLogoSelection={null} />
 
-      <p>
+      <Typography
+        variant="h6"
+        sx={{
+          textAlign: "end",
+          p: 2,
+          mt: 5,
+          mb: 10,
+          mr: 20,
+        }}
+      >
         {result.count === 0
           ? `No logo found`
           : `Shows ${result.logos.length} on ${result.count ?? 0} available`}
-      </p>
+      </Typography>
     </Box>
   );
 }


### PR DESCRIPTION
For logo search/annotation I display the key below (not only the translation, assuming users know how to works)

![image](https://user-images.githubusercontent.com/45398769/191613424-daf2ed33-4a92-4464-bdde-88de2414fbec.png)

Fix #175 

To the far right, I added a link to the search interface

![image](https://user-images.githubusercontent.com/45398769/191613936-db4fdeda-73b0-4dd8-a43c-f8fd6e2f23ee.png)
