### PR TITLE
feat: Show debug informations about insights

### DIFF
--- a/src/contexts/devMode.jsx
+++ b/src/contexts/devMode.jsx
@@ -1,9 +1,14 @@
 import * as React from "react";
-import { getIsDevMode, getVisiblePages } from "../localeStorageManager";
+import {
+  getIsDevMode,
+  getVisiblePages,
+  getPageCustomization,
+} from "../localeStorageManager";
 
 const DevModeContext = React.createContext({
   devMode: getIsDevMode(),
   visiblePages: getVisiblePages(),
+  pageCustomization: getPageCustomization(),
 });
 
 export default DevModeContext;

--- a/src/localeStorageManager.ts
+++ b/src/localeStorageManager.ts
@@ -10,6 +10,7 @@ export const localSettingsKeys = {
   showTour: "showTour",
   showDatabase: "showDatabase",
   showNutriscore: "showNutriscore",
+  pageCustomization: "pageCustomization",
 };
 
 export const localSettings = {
@@ -32,12 +33,15 @@ export const localSettings = {
   },
 };
 
-export const getIsDevMode = () => {
+export const getIsDevMode: () => boolean = () => {
   const settings = localSettings.fetch();
   return settings[localSettingsKeys.isDevMode] ?? false;
 };
 
-export const getVisiblePages = () => {
+export const getVisiblePages: () => {
+  nutriscore: boolean;
+  insights: boolean;
+} = () => {
   const settings = localSettings.fetch();
   return (
     settings[localSettingsKeys.visiblePages] ?? {
@@ -45,6 +49,21 @@ export const getVisiblePages = () => {
       insights: true,
     }
   );
+};
+
+export const getPageCustomization: () => {
+  questionPage: {
+    showDebug: boolean;
+    showOtherQuestions: boolean;
+  };
+} = () => {
+  // const settings = localSettings.fetch();
+  return {
+    questionPage: {
+      showDebug: true,
+      showOtherQuestions: true,
+    },
+  };
 };
 
 /** Questions page: returns a boolean for hiding the images. Uses local storage.  */
@@ -67,6 +86,7 @@ export const getLang = () => {
   return (
     urlLanguage ||
     settings[localSettingsKeys.language] ||
+    // @ts-ignore
     (navigator.language || navigator.userLanguage).split("-")[0]
   );
 };

--- a/src/pages/questions/DebugQuestion.tsx
+++ b/src/pages/questions/DebugQuestion.tsx
@@ -18,9 +18,8 @@ import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
 
 const fetchData = async (insightId) => {
-  const responce = await robotoff.insightDetail(insightId);
-  console.log(responce);
-  return responce;
+  const response = await robotoff.insightDetail(insightId);
+  return response;
 };
 
 const getCroppedLogoUrl = (debugData) => {
@@ -38,7 +37,14 @@ const DebugQuestion = (props) => {
   const { insightId } = props;
   const [isLoading, setIsLoading] = React.useState(true);
   const [debugData, setDebugData] = React.useState<any>({});
-  const [mageUrl, setImageUrl] = React.useState<any>(null);
+  const [openDetails, setOpenDetails] = React.useState<any>({
+    resume: false,
+    json_details: false,
+  });
+
+  const handleChange = (panelId) => (event, newState) => {
+    setOpenDetails((prev) => ({ ...prev, [panelId]: newState }));
+  };
 
   React.useEffect(() => {
     setIsLoading(true);
@@ -68,7 +74,11 @@ const DebugQuestion = (props) => {
     <>
       <Divider sx={{ mt: 2 }} />
       <Box sx={{ px: 2, my: 2 }}>
-        <Accordion variant="outlined">
+        <Accordion
+          variant="outlined"
+          onChange={handleChange("resume")}
+          expanded={openDetails["resume"]}
+        >
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls="panel1a-content"
@@ -119,7 +129,11 @@ const DebugQuestion = (props) => {
             )}
           </AccordionDetails>
         </Accordion>
-        <Accordion variant="outlined">
+        <Accordion
+          variant="outlined"
+          onChange={handleChange("json_details")}
+          expanded={openDetails["json_details"]}
+        >
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls="panel1a-content"

--- a/src/pages/questions/DebugQuestion.tsx
+++ b/src/pages/questions/DebugQuestion.tsx
@@ -1,0 +1,145 @@
+import * as React from "react";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import Typography from "@mui/material/Typography";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import LinearProgress from "@mui/material/LinearProgress";
+
+import robotoff from "../../robotoff";
+import off from "../../off";
+
+import Divider from "@mui/material/Divider";
+import Box from "@mui/material/Box";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableRow from "@mui/material/TableRow";
+import TableCell from "@mui/material/TableCell";
+
+const fetchData = async (insightId) => {
+  const responce = await robotoff.insightDetail(insightId);
+  console.log(responce);
+  return responce;
+};
+
+const getCroppedLogoUrl = (debugData) => {
+  if (!debugData?.source_image || !debugData?.data?.bounding_box) {
+    return null;
+  }
+
+  const sourceImage = off.getImageUrl(debugData?.source_image);
+  return robotoff.getCroppedImageUrl(
+    sourceImage,
+    debugData?.data?.bounding_box
+  );
+};
+const DebugQuestion = (props) => {
+  const { insightId } = props;
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [debugData, setDebugData] = React.useState<any>({});
+  const [mageUrl, setImageUrl] = React.useState<any>(null);
+
+  React.useEffect(() => {
+    setIsLoading(true);
+    let isValid = true;
+    fetchData(insightId)
+      .then(({ data }) => {
+        if (!isValid) {
+          return;
+        }
+        setIsLoading(false);
+        setDebugData(data);
+      })
+      .catch((e) => {
+        if (!isValid) {
+          return;
+        }
+        setIsLoading(false);
+        setDebugData(e);
+      });
+    return () => {
+      isValid = false;
+    };
+  }, [insightId]);
+
+  const croppedUrl = getCroppedLogoUrl(debugData);
+  return (
+    <>
+      <Divider sx={{ mt: 2 }} />
+      <Box sx={{ px: 2, my: 2 }}>
+        <Accordion variant="outlined">
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            <Typography>resume</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            {isLoading ? (
+              <LinearProgress />
+            ) : (
+              <div>
+                <Table size="small">
+                  <TableBody
+                    sx={{
+                      " td, th": { border: "none" },
+                      th: { verticalAlign: "top", pr: 0 },
+                    }}
+                  >
+                    <TableRow>
+                      <TableCell component="th" scope="row">
+                        insight id
+                      </TableCell>
+                      <TableCell>{debugData?.id}</TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell component="th" scope="row">
+                        generator model
+                      </TableCell>
+                      <TableCell>{debugData?.predictor}</TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell component="th" scope="row">
+                        timestamp
+                      </TableCell>
+                      <TableCell>
+                        {new Date(debugData?.timestamp).toLocaleString()}
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+                {croppedUrl && (
+                  <img alt="lroUsed for prediction" src={croppedUrl} />
+                )}
+              </div>
+            )}
+          </AccordionDetails>
+        </Accordion>
+        <Accordion variant="outlined">
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            <Typography>raw JSON</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            {isLoading ? (
+              <LinearProgress />
+            ) : (
+              <Typography variant="caption" component="pre">
+                {JSON.stringify(debugData, null, 2)}
+              </Typography>
+            )}
+          </AccordionDetails>
+        </Accordion>
+      </Box>
+    </>
+  );
+};
+
+export default DebugQuestion;

--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -26,8 +26,11 @@ import {
   localSettings,
   localSettingsKeys,
   getHideImages,
+  getPageCustomization,
+  getIsDevMode,
 } from "../../localeStorageManager";
 import externalApi from "../../externalApi";
+import DebugQuestion from "./DebugQuestion";
 
 // src looks like: "https://static.openfoodfacts.org/images/products/004/900/053/2258/1.jpg"
 const getImageId = (src) => {
@@ -49,8 +52,13 @@ const getImagesUrls = (images, barcode) => {
 
 const ProductInformation = ({ question }) => {
   const { t } = useTranslation();
+  const isDevMode = getIsDevMode();
+
   const [productData, setProductData] = React.useState({});
   const [hideImages, setHideImages] = React.useState(getHideImages);
+  const [devCustomization, setDevCustomization] = React.useState(
+    () => getPageCustomization().questionPage
+  );
   const [flagged, setFlagged] = React.useState([]);
 
   const flagImage = (src, barcode) => {
@@ -186,7 +194,7 @@ const ProductInformation = ({ question }) => {
       {/* Remaining info */}
       <Divider />
 
-      <Table size="small" aria-label="a dense table">
+      <Table size="small">
         <TableBody
           sx={{
             " td, th": { border: "none" },
@@ -219,6 +227,9 @@ const ProductInformation = ({ question }) => {
           </TableRow>
         </TableBody>
       </Table>
+      {isDevMode && devCustomization.showDebug && (
+        <DebugQuestion insightId={question.insight_id} />
+      )}
       <Divider />
     </Box>
   );

--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -117,9 +117,6 @@ const ProductInformation = ({ question }) => {
   if (!question || question.insight_id === NO_QUESTION_LEFT) {
     return null;
   }
-  if (productData.isLoading) {
-    return <p>loading...</p>;
-  }
 
   return (
     <Box>


### PR DESCRIPTION
Fix #221

Mostly for usage on desktop. It adds two elements:
- The first one is a resume with the basic information you wanted. I put the 3 requested information, plus a crop of the logo.
- The second one is simply a print of the insight as a JSON

![image](https://user-images.githubusercontent.com/45398769/192050966-9bcc9eb0-62fa-4174-a93a-a75807f1299b.png)
