### PR TITLE
Fix insights service call for non-annotated search

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -133,6 +133,7 @@ const robotoff = {
     let annotated;
     if (annotation.length && annotation === "not_annotated") {
       annotated = "0";
+      annotation = "";
     }
     return axios.get(`${ROBOTOFF_API_URL}/insights`, {
       params: removeEmptyKeys({


### PR DESCRIPTION
### What
- Fixes Insights service call for non-annotated search. The annotation parameter is not sent when the annotation is "non-annotated".

### Screenshot
![hunger-games-fix](https://user-images.githubusercontent.com/59290226/193412509-6b4d00b8-0029-402e-aebb-6852d9b7e157.png)


### Fixes bug(s)
- Fix #230 

### Part of 
- #230 
