### PR TITLE
fix: keep already set filter parameters

### DIFF
--- a/src/components/QuestionCard.jsx
+++ b/src/components/QuestionCard.jsx
@@ -19,21 +19,12 @@ import ClearIcon from "@mui/icons-material/Clear";
 import robotoff from "../robotoff";
 import { localFavorites } from "../localeStorageManager";
 import logo from "../assets/logo.png";
-import { reformatValueTag } from "../utils";
 import { getQuestionSearchParams } from "./QuestionFilter";
 import { useTranslation } from "react-i18next";
 
 const QuestionCard = (props) => {
   const { filterState, imageSrc, title, showFilterResume, editableTitle } =
     props;
-  const {
-    sortByPopularity,
-    insightType,
-    valueTag,
-    brandFilter,
-    countryFilter,
-    campaign,
-  } = filterState;
 
   const { t } = useTranslation();
 
@@ -43,35 +34,15 @@ const QuestionCard = (props) => {
 
   React.useEffect(() => {
     let isValid = true;
-    robotoff
-      .questions(
-        {
-          sortBy: sortByPopularity ? "popular" : "random",
-          insightType,
-          valueTag,
-          brands: reformatValueTag(brandFilter),
-          country: countryFilter !== "en:world" ? countryFilter : null,
-          campaign,
-        },
-        1,
-        1
-      )
-      .then(({ data }) => {
-        if (isValid) {
-          setQuestionNumber(data?.count ?? 0);
-        }
-      });
+    robotoff.questions(filterState, 1, 1).then(({ data }) => {
+      if (isValid) {
+        setQuestionNumber(data?.count ?? 0);
+      }
+    });
     return () => {
       isValid = false;
     };
-  }, [
-    sortByPopularity,
-    insightType,
-    valueTag,
-    brandFilter,
-    countryFilter,
-    campaign,
-  ]);
+  }, [filterState]);
 
   const [isEditMode, setIsEditMode] = React.useState(false);
   const [innerTitle, setInnerTitle] = React.useState(title);

--- a/src/pages/questions/QuestionDisplay.jsx
+++ b/src/pages/questions/QuestionDisplay.jsx
@@ -22,6 +22,7 @@ import {
 } from "../../const";
 import { reformatValueTag } from "../../utils";
 import robotoff from "../../robotoff";
+import { getQuestionSearchParams } from "../../components/QuestionFilter/useFilterSearch";
 
 // const getFullSizeImage = (src) => {
 //   if (!src) {
@@ -35,7 +36,7 @@ import robotoff from "../../robotoff";
 //   return src.replace("400.jpg", "jpg");
 // };
 
-const getValueTagQuestionsURL = (question) => {
+const getValueTagQuestionsURL = (filterState, question) => {
   if (
     question !== null &&
     question &&
@@ -45,7 +46,11 @@ const getValueTagQuestionsURL = (question) => {
     const urlParams = new URLSearchParams();
     urlParams.append("type", question.insight_type);
     urlParams.append("value_tag", reformatValueTag(question.value_tag));
-    return `/questions?${urlParams.toString()}`;
+    return `/questions?${getQuestionSearchParams({
+      ...filterState,
+      insightType: question.insight_type,
+      valueTag: question.value_tag,
+    })}`;
   }
   return null;
 };
@@ -64,11 +69,8 @@ const getValueTagExamplesURL = (question) => {
   return "";
 };
 
-const getNbOfQuestionForValue = async ({ type, valueTag }) => {
-  const { data: dataFetched } = await robotoff.questions(
-    { sortBy: "random", insightType: type, valueTag },
-    1
-  );
+const getNbOfQuestionForValue = async (filterState) => {
+  const { data: dataFetched } = await robotoff.questions(filterState, 1);
   return dataFetched.count;
 };
 
@@ -79,7 +81,7 @@ const QuestionDisplay = ({
   filterState,
 }) => {
   const { t } = useTranslation();
-  const valueTagQuestionsURL = getValueTagQuestionsURL(question);
+  const valueTagQuestionsURL = getValueTagQuestionsURL(filterState, question);
   const valueTagExamplesURL = getValueTagExamplesURL(question);
   const [nbOfPotentialQuestion, setNbOfPotentialQuestions] =
     React.useState(null);
@@ -97,7 +99,8 @@ const QuestionDisplay = ({
     let validRequest = true;
 
     getNbOfQuestionForValue({
-      type: question?.insight_type,
+      ...filterState,
+      insightType: question?.insight_type,
       valueTag: question?.value_tag,
     })
       .then((nbQuestions) => {
@@ -110,7 +113,7 @@ const QuestionDisplay = ({
     return () => {
       validRequest = false;
     };
-  }, [filterState.valueTag, question?.insight_type, question?.value_tag]);
+  }, [filterState, question?.insight_type, question?.value_tag]);
 
   React.useEffect(() => {
     function handleShortCut(event) {

--- a/src/pages/questions/useQuestionBuffer.ts
+++ b/src/pages/questions/useQuestionBuffer.ts
@@ -1,32 +1,14 @@
 import React from "react";
 import { NO_QUESTION_LEFT, SKIPPED_INSIGHT } from "../../const";
 import robotoff, { QuestionInterface } from "../../robotoff";
-import { reformatValueTag } from "../../utils";
 
 const PAGE_SIZE = 10;
 const BUFFER_THRESHOLD = 5;
 const DEFAULT_ANSWER_DELAY = 5000;
 
 const loadQuestions = async (filterState, page = 1, pageSize = PAGE_SIZE) => {
-  const {
-    insightType,
-    brandFilter,
-    valueTag,
-    countryFilter,
-    sortByPopularity,
-    campaign,
-  } = filterState;
-
-  console.log({ insightType });
   const { data: dataFetched } = await robotoff.questions(
-    {
-      sortBy: sortByPopularity ? "popular" : "random",
-      insightType,
-      valueTag,
-      brands: reformatValueTag(brandFilter),
-      country: countryFilter !== "en:world" ? countryFilter : null,
-      campaign,
-    },
+    filterState,
     pageSize,
     page
   );

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { ROBOTOFF_API_URL, IS_DEVELOPMENT_MODE } from "./const";
 import { getLang } from "./localeStorageManager";
-import { removeEmptyKeys } from "./utils";
+import { reformatValueTag, removeEmptyKeys } from "./utils";
 
 export interface QuestionInterface {
   barcode: string;
@@ -49,28 +49,35 @@ const robotoff = {
       });
   },
 
-  questions(searchParams, count = 10, page) {
+  questions(filterState, count = 10, page) {
     const {
-      sortBy = "popular",
       insightType,
+      brandFilter,
       valueTag,
-      brands,
-      country,
+      countryFilter,
+      sortByPopularity,
       campaign,
-    } = searchParams;
+    } = filterState;
+
+    const searchParams = {
+      insight_types: insightType,
+      value_tag: valueTag,
+      brands: reformatValueTag(brandFilter),
+      country: countryFilter !== "en:world" ? countryFilter : null,
+      campaign,
+    };
+
     const lang = getLang();
 
     console.log(searchParams);
     return axios.get<GetQuestionsResponse>(
-      `${ROBOTOFF_API_URL}/questions/${sortBy}`,
+      `${ROBOTOFF_API_URL}/questions/${
+        sortByPopularity ? "popular" : "random"
+      }`,
       {
         params: removeEmptyKeys({
+          ...searchParams,
           lang,
-          insight_types: insightType,
-          value_tag: valueTag,
-          brands,
-          country,
-          campaign,
           count,
           page,
         }),


### PR DESCRIPTION
When clicking on the link for a given value, it should not remove the filter parameters already set

For example when clicking on fruit juice:
- currently: `country: France` become `type: category, value: fruit juice`
- now: `country: France` become `country: France, type: category, value: fruit juice` 