### PR TITLE
matomo: Track answered questions

### DIFF
--- a/src/hooks/matomoEvents.ts
+++ b/src/hooks/matomoEvents.ts
@@ -1,0 +1,16 @@
+import { useMatomo } from "@jonkoops/matomo-tracker-react";
+import { CORRECT_INSIGHT, WRONG_INSIGHT, SKIPPED_INSIGHT } from "../const";
+
+const mapValueToAction = {
+  [CORRECT_INSIGHT]: "yes",
+  [WRONG_INSIGHT]: "no",
+  [SKIPPED_INSIGHT]: "skip",
+};
+
+export const useMatomoTrackAnswerQuestion = () => {
+  const { trackEvent } = useMatomo();
+
+  return (answer: -1 | 0 | 1) => {
+    trackEvent({ category: "question-page", action: mapValueToAction[answer] });
+  };
+};

--- a/src/pages/questions/useQuestionBuffer.ts
+++ b/src/pages/questions/useQuestionBuffer.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { NO_QUESTION_LEFT } from "../../const";
+import { useMatomoTrackAnswerQuestion } from "../../hooks/matomoEvents";
 import robotoff, { QuestionInterface } from "../../robotoff";
 
 const PAGE_SIZE = 10;
@@ -195,16 +196,18 @@ export const useQuestionBuffer = (
     countryFilter,
     campaign,
   });
+  const trackAnswer = useMatomoTrackAnswerQuestion();
 
   const answerQuestion = React.useCallback(
     ({ value, insightId, pendingDelay = DEFAULT_ANSWER_DELAY }) => {
+      trackAnswer(value);
       seenInsight.current.push(insightId);
       dispatch({
         type: "annotate",
         payload: { insightId, value, pendingDelay },
       });
     },
-    []
+    [trackAnswer]
   );
 
   const preventAnnotation = React.useCallback((insightId) => {


### PR DESCRIPTION
The goal of hunger games is to annotate products. To know if we are doing good, we need to know how many products get annotated by users.

In this PR we send a matomo action each time a user is answering a question