### PR TITLE
feat: Split interface for fast nutriscore answer and INAO logos

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,8 @@ import {
   QuestionsPage,
   InsightsPage,
   NotFoundPage,
-  NutriscoreValidator,
+  NutriscorePageValidator,
+  INAOPageValidator,
   Home,
   Nutrition,
   FlaggedImages,
@@ -52,13 +53,29 @@ const ADMINS = [
 export default function App() {
   const [devMode, setDevMode] = React.useState(getIsDevMode);
   const [visiblePages, setVisiblePages] = React.useState(getVisiblePages);
-  const [userState, setUserState] = React.useState({
-    userName: "",
-    isLoggedIn: false,
+  const [userState, setUserState] = React.useState(() => {
+    if (IS_DEVELOPMENT_MODE) {
+      return {
+        userName: "",
+        isLoggedIn: true,
+      };
+    }
+    return {
+      userName: "",
+      isLoggedIn: false,
+    };
   });
   const lastSeenCookie = React.useRef(null);
 
   const refresh = React.useCallback(async () => {
+    if (IS_DEVELOPMENT_MODE) {
+      setUserState({
+        userName: "",
+        isLoggedIn: true,
+      });
+      return true;
+    }
+
     const sessionCookie = off.getCookie("session");
     if (sessionCookie === lastSeenCookie.current) {
       return userState.isLoggedIn;
@@ -228,12 +245,23 @@ export default function App() {
                 path="/nutriscore"
                 element={
                   userState.isLoggedIn ? (
-                    <NutriscoreValidator />
+                    <NutriscorePageValidator />
                   ) : (
                     <ShouldLoggedinPage />
                   )
                 }
               />
+              <Route
+                path="/inao"
+                element={
+                  userState.isLoggedIn ? (
+                    <INAOPageValidator />
+                  ) : (
+                    <ShouldLoggedinPage />
+                  )
+                }
+              />
+
               <Route
                 path="/nutrition"
                 element={

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ export { default as ProductLogoAnnotationPage } from "./logos/ProductLogoAnnotat
 export { default as LogoDeepSearch } from "./logos/LogoDeepSearch";
 
 // experimental
-export { default as NutriscoreValidator } from "./nutriscoreValidator";
+export { NutriscorePageValidator, INAOPageValidator } from "./logosValidator";
 export { default as FlaggedImages } from "./flaggedImages";
 
 export { default as ShouldLoggedinPage } from "./shouldLoggedinPage";

--- a/src/pages/logosValidator/index.jsx
+++ b/src/pages/logosValidator/index.jsx
@@ -1,0 +1,54 @@
+import LogoQuestionValidator from "./LogoQuestionValidator";
+
+const NUTRISCORE_OPTIONS = [
+  { tag: "en:nutriscore-grade-a", label: "Nutriscore A" },
+  { tag: "en:nutriscore-grade-b", label: "Nutriscore B" },
+  { tag: "en:nutriscore-grade-c", label: "Nutriscore C" },
+  { tag: "en:nutriscore-grade-d", label: "Nutriscore D" },
+  { tag: "en:nutriscore-grade-e", label: "Nutriscore E" },
+];
+
+const INAO_OTIONS = [
+  {
+    tag: "fr:ab-agriculture-biologique",
+    label: "AB (Agriculture Bio)",
+    logo: "https://static.openfoodfacts.org/images/lang/fr/labels/ab-agriculture-biologique.74x90.svg",
+  },
+  {
+    tag: "en:eu-organic",
+    label: "Bio Européen",
+    logo: "https://static.openfoodfacts.org/images/lang/fr/labels/bio-europeen.135x90.png",
+  },
+  {
+    tag: "en:pdo",
+    label: "AOP (Appelation d'Origine Contrôlée)",
+    link: "https://www.inao.gouv.fr/Les-signes-officiels-de-la-qualite-et-de-l-origine-SIQO/Appellation-d-origine-protegee-controlee-AOP-AOC",
+    logo: "https://static.openfoodfacts.org/images/lang/fr/labels/aop.90x90.svg",
+  },
+  {
+    tag: "en:pgi",
+    label: "IGP (Indication Géographique Protégée)",
+    link: "https://www.inao.gouv.fr/Les-signes-officiels-de-la-qualite-et-de-l-origine-SIQO/Indication-geographique-protegee",
+    logo: "https://static.openfoodfacts.org/images/lang/fr/labels/igp.90x90.svg",
+  },
+  {
+    tag: "en:tsg",
+    label: "Spécialité traditionnelle garantie (STG)",
+    link: "https://www.inao.gouv.fr/Les-signes-officiels-de-la-qualite-et-de-l-origine-SIQO/Specialite-traditionnelle-garantie-STG",
+    logo: "https://static.openfoodfacts.org/images/lang/fr/labels/stg.90x90.svg",
+  },
+  {
+    tag: "fr:label-rouge",
+    label: "Label Rouge",
+    link: "https://www.inao.gouv.fr/Les-signes-officiels-de-la-qualite-et-de-l-origine-SIQO/Label-Rouge",
+    logo: "https://static.openfoodfacts.org/images/lang/fr/labels/label-rouge.90x90.svg",
+  },
+];
+
+export const NutriscorePageValidator = () => {
+  return <LogoQuestionValidator options={NUTRISCORE_OPTIONS} />;
+};
+
+export const INAOPageValidator = () => {
+  return <LogoQuestionValidator options={INAO_OTIONS} />;
+};

--- a/src/pages/questions/useQuestionBuffer.ts
+++ b/src/pages/questions/useQuestionBuffer.ts
@@ -187,7 +187,8 @@ export const useQuestionBuffer = (
     campaign,
   },
   pageSize,
-  bufferThreshold = BUFFER_THRESHOLD
+  bufferThreshold = BUFFER_THRESHOLD,
+  filterItem = (q) => true
 ) => {
   const [bufferState, dispatch] = React.useReducer<
     React.Reducer<ReducerStateInterface, Actions>
@@ -263,13 +264,18 @@ export const useQuestionBuffer = (
       loadQuestions(filteringRef.current, bufferState.page, pageSize)
         .then(({ isLastPage, questions, availableQuestionsNb }) => {
           if (filterIsStillValid) {
-            const filteredQuestions = questions.filter(
-              (question) => !seenInsight.current.includes(question.insight_id)
-            );
+            console.log("filtering");
+            const filteredQuestions = questions
+              .filter(
+                (question) => !seenInsight.current.includes(question.insight_id)
+              )
+              .filter(filterItem);
+
             const removedInsightIds = questions
               .filter((question) =>
                 seenInsight.current.includes(question.insight_id)
               )
+
               .map((q) => q.insight_id);
 
             dispatch({
@@ -300,6 +306,7 @@ export const useQuestionBuffer = (
     bufferState.page,
     pageSize,
     bufferThreshold,
+    filterItem,
   ]);
 
   React.useEffect(() => {


### PR DESCRIPTION
Sounds like AOP/AOC logos ned some cleaning, So I created a similar annotator than the one for nutriscore logo detection

![image](https://user-images.githubusercontent.com/45398769/206003103-f80ae4ee-1a6f-467c-bbd1-07781b6d837a.png)


The only problem is that AOC and AOP questions can also be generated from OCR, then I don't have image to display. Then after some time the user has to refresh the page to get new bath of logos