### PR TITLE
fix: Adapt Hunger Games to the ANN modification in Robotoff

### DIFF
--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -51,15 +51,10 @@ const loadLogos = async (
   alreadyLoadedData = []
 ) => {
   const {
-    data: { results },
+    data: { results, query_logo_id },
   } = await robotoff.getLogoAnnotations(targetLogoId, index, annotationCount);
 
-  if (targetLogoId && results[0].distance !== 0) {
-    // If requested logo is not yet indexed, it will not find himself has a nearest neighbor of distance 0
-    // In such a case we add it manually
-    // see: https://github.com/openfoodfacts/hunger-games/issues/287
-    results.unshift({ logo_id: Number.parseInt(targetLogoId), distance: 0 });
-  }
+  results.unshift({ logo_id: Number.parseInt(query_logo_id), distance: 0 });
 
   const seenIds = {};
   alreadyLoadedData.forEach(({ id }) => {

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -123,8 +123,8 @@ const robotoff = {
   getLogoAnnotations(logoId, index, count = 25) {
     const url =
       logoId.length > 0
-        ? `${ROBOTOFF_API_URL}/ann/${logoId}`
-        : `${ROBOTOFF_API_URL}/ann`;
+        ? `${ROBOTOFF_API_URL}/ann/search/${logoId}`
+        : `${ROBOTOFF_API_URL}/ann/search`;
     return axios.get(url, {
       params: removeEmptyKeys({
         index,


### PR DESCRIPTION
### What
- Changed route for ANN search
- The robotoff ANN search now returns the query logo id in a field "query_logo_id". Added this id to the results of ANN search, replacing the work done in #294.

### Important
- Should wait the deployment of the new ANN search in Robotoff (expected for the 26th of december).

