### PR TITLE
feat: add loading animation before question display

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -114,7 +114,8 @@
     "log_in": "Login",
     "sign_up": "Sign up",
     "login_title": "Make your annotation count",
-    "login_description": "Currently you are not logged in Open Food Facts. To get your answers directly applied to products, and associated to your account, consider logging in to your Open Food Facts account, or creating one"
+    "login_description": "Currently you are not logged in Open Food Facts. To get your answers directly applied to products, and associated to your account, consider logging in to your Open Food Facts account, or creating one",
+    "please_wait_while_we_fetch_the_question":"Please wait while we fetch the question!"
   },
   "menu": {
     "title": "Hunger Games",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -114,7 +114,8 @@
     "log_in": "Login",
     "sign_up": "Sign up",
     "login_title": "Make your annotation count",
-    "login_description": "Currently you are not logged in Open Food Facts. To get your answers directly applied to products, and associated to your account, consider logging in to your Open Food Facts account, or creating one"
+    "login_description": "Currently you are not logged in Open Food Facts. To get your answers directly applied to products, and associated to your account, consider logging in to your Open Food Facts account, or creating one",
+    "please_wait_while_we_fetch_the_question":"Please wait while we fetch the question!"
   },
   "menu": {
     "title": "Hunger Games",

--- a/src/pages/questions/QuestionDisplay.jsx
+++ b/src/pages/questions/QuestionDisplay.jsx
@@ -177,7 +177,7 @@ const QuestionDisplay = ({
   }
   if (question === null) {
     return (
-      <Box sx={{ width: "100vw", textAlign: "center", py: 10, m: 0 }}>
+      <Box sx={{ width: "100%", textAlign: "center", py: 10, m: 0 }}>
         <Typography variant="subtitle1">
           {t("questions.please_wait_while_we_fetch_the_question")}
         </Typography>

--- a/src/pages/questions/QuestionDisplay.jsx
+++ b/src/pages/questions/QuestionDisplay.jsx
@@ -10,6 +10,7 @@ import Typography from "@mui/material/Typography";
 import LinkIcon from "@mui/icons-material/Link";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DoneIcon from "@mui/icons-material/Done";
+import CircularProgress from "@mui/material/CircularProgress";
 import MuiLink from "@mui/material/Link";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -28,7 +29,6 @@ import { getShortcuts } from "../../l10n-shortcuts";
 import { getQuestionSearchParams } from "../../components/QuestionFilter/useFilterSearch";
 import CroppedLogo from "../../components/CroppedLogo";
 import ZoomableImage from "../../components/ZoomableImage";
-import { CircularProgress } from "@mui/material";
 
 const getFullSizeImage = (src) => {
   if (!src) {

--- a/src/pages/questions/QuestionDisplay.jsx
+++ b/src/pages/questions/QuestionDisplay.jsx
@@ -28,6 +28,7 @@ import { getShortcuts } from "../../l10n-shortcuts";
 import { getQuestionSearchParams } from "../../components/QuestionFilter/useFilterSearch";
 import CroppedLogo from "../../components/CroppedLogo";
 import ZoomableImage from "../../components/ZoomableImage";
+import { CircularProgress } from "@mui/material";
 
 const getFullSizeImage = (src) => {
   if (!src) {
@@ -175,7 +176,15 @@ const QuestionDisplay = ({
     );
   }
   if (question === null) {
-    return <p>loading</p>;
+    return (
+      <Box sx={{ width: "100vw", textAlign: "center", py: 10, m: 0 }}>
+        <Typography variant="subtitle1">
+          {t("questions.please_wait_while_we_fetch_the_question")}
+        </Typography>
+        <br />
+        <CircularProgress />
+      </Box>
+    );
   }
   return (
     <Stack


### PR DESCRIPTION
Fix #496

- before it was showing only loading text, now it shows loading circular animation

### Fixes bug(s)
- #496 <!-- #1, #2 and #3 (change by appropriate issues) -->

