### PR TITLE
Add synonyms to `useUrlParams`

### DIFF
--- a/src/components/QuestionFilter/useFilterSearch.js
+++ b/src/components/QuestionFilter/useFilterSearch.js
@@ -34,7 +34,8 @@ export function useFilterSearch() {
   // This hook do the translation
 
   const [urlSearchParams, setUrlSearchParams] = useUrlParams(
-    DEFAULT_FILTER_URL_PARAMS
+    DEFAULT_FILTER_URL_PARAMS,
+    { valueTag: ["value_tag", "value"] }
   );
   const exposedParameters = React.useMemo(
     () => convertUrlToParams(urlSearchParams),

--- a/src/hooks/useUrlParams.js
+++ b/src/hooks/useUrlParams.js
@@ -70,6 +70,13 @@ export const convertObjectParamsToUrlParams = (
   return urlParams.toString();
 };
 
+/**
+ * Hook that works as useState to keep in sync with URL query params
+ * @param {object} defaultParams The object to get from the URL
+ * @param {object} synonyms The synonmys under the form { valueKeyA: ['synonymA1', 'synsonymA2'], valueKeyB: 'synsonlymB1' }.
+ * If the urls containg a paramter named `synonymA1` it will be used to override valueKeyA value.
+ * @returns [state, setState]
+ */
 const useUrlParams = (defaultParams, synonyms) => {
   const [parameters, setParameters] = React.useState(() =>
     getDefaultizedUrlParams(defaultParams)

--- a/src/pages/insights/index.jsx
+++ b/src/pages/insights/index.jsx
@@ -12,12 +12,17 @@ import useUrlParams from "../../hooks/useUrlParams";
 export default function Insights() {
   const { t } = useTranslation();
 
-  const [filterState, setFilterState] = useUrlParams({
-    barcode: "",
-    valueTag: "",
-    insightType: "",
-    annotationStatus: "",
-  });
+  const [filterState, setFilterState] = useUrlParams(
+    {
+      barcode: "",
+      valueTag: "",
+      insightType: "",
+      annotationStatus: "",
+    },
+    {
+      valueTag: ["value", "value_tag"],
+    }
+  );
 
   return (
     <Stack spacing={2} sx={{ padding: 2 }}>

--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -84,7 +84,7 @@ export default function LogoAnnotation() {
   const { t } = useTranslation();
   const theme = useTheme();
 
-  const [logoSearchParams] = useUrlParams(DEFAULT_LOGO_SEARCH_STATE);
+  const [logoSearchParams] = useUrlParams(DEFAULT_LOGO_SEARCH_STATE, {});
 
   const [logoState, setLogoState] = React.useState(DEFAULT_LOGO_STATE);
 

--- a/src/pages/logos/LogoDeepSearch.jsx
+++ b/src/pages/logos/LogoDeepSearch.jsx
@@ -48,7 +48,12 @@ export default function LogoSearch() {
   const [logosToAnnotate, setLogosToAnnotate] = React.useState([]);
   // TODO: allows to fetch more when reaching data limit
   const [searchCount] = React.useState(DEFAULT_COUNT);
-  const [searchState, setSearchState] = useUrlParams({ type: "", value: "" });
+  const [searchState, setSearchState] = useUrlParams(
+    { type: "", value: "" },
+    {
+      value: ["valueTag", "value_tag"],
+    }
+  );
   const pageSize = 50;
   const [page, setPage] = React.useState(1);
 

--- a/src/pages/logos/LogoSearch.jsx
+++ b/src/pages/logos/LogoSearch.jsx
@@ -42,12 +42,15 @@ export default function LogoSearch() {
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = React.useState(true);
-  const [searchState, setSearchState] = useUrlParams({
-    type: "",
-    value: "",
-    barcode: "",
-    count: 25,
-  });
+  const [searchState, setSearchState] = useUrlParams(
+    {
+      type: "",
+      value: "",
+      barcode: "",
+      count: 25,
+    },
+    { value: ["value_tag", "valueTag"] }
+  );
 
   const [result, setResult] = React.useState({ logos: [], count: undefined });
 

--- a/src/pages/logos/ProductLogoAnnotations.jsx
+++ b/src/pages/logos/ProductLogoAnnotations.jsx
@@ -190,11 +190,17 @@ const useLogoFetching = (filter) => {
 };
 
 export default function AnnotateLogosFromProducts() {
-  const [filter, setFilter] = useUrlParams({
-    tagtype: "labels",
-    tag_contains: "contains",
-    tag: "en:eg-oko-verordnung",
-  });
+  const [filter, setFilter] = useUrlParams(
+    {
+      tagtype: "labels",
+      tag_contains: "contains",
+      tag: "en:eg-oko-verordnung",
+    },
+    {
+      tag: ["valueTag", "value_tag", "value"],
+      tagType: "type",
+    }
+  );
 
   const [internalFilter, setInternalFilter] = React.useState(() => filter);
   React.useEffect(() => {

--- a/src/pages/logosValidator/LogoQuestionValidator.jsx
+++ b/src/pages/logosValidator/LogoQuestionValidator.jsx
@@ -127,10 +127,13 @@ const LogoQuesitonCard = (props) => {
 export default function LogoQuestionValidator({ predictor }) {
   const { t } = useTranslation();
 
-  const [controlledState, setControlledState] = useUrlParams({
-    imageSize: 200,
-    zoomOnLogo: true,
-  });
+  const [controlledState, setControlledState] = useUrlParams(
+    {
+      imageSize: 200,
+      zoomOnLogo: true,
+    },
+    {}
+  );
   const { valueTag } = useParams();
   const imageSize = Number.parseInt(controlledState.imageSize);
   const zoomOnLogo = JSON.parse(controlledState.zoomOnLogo);

--- a/src/pages/packaging/index.tsx
+++ b/src/pages/packaging/index.tsx
@@ -246,11 +246,14 @@ const Page = () => {
   const packagingMaterials = useOptions("packaging_materials", lang);
   const packagingShapes = useOptions("packaging_shapes", lang);
   const packagingRecycling = useOptions("packaging_recycling", lang);
-  const [searchState] = useUrlParams({
-    country: "en:france",
-    creator: undefined,
-    code: "",
-  });
+  const [searchState] = useUrlParams(
+    {
+      country: "en:france",
+      creator: undefined,
+      code: "",
+    },
+    {}
+  );
 
   const [rows, setRows] = React.useState([]);
   const [innerRows, setInnerRows] = React.useState([]);


### PR DESCRIPTION
Solves https://github.com/openfoodfacts/facets-knowledge-panels/issues/80


@sumit-158 You can now (after PR merge of course 😉) use `value_tag` in all urls. Is there other parameters that are problematic?