### PR TITLE
Fix: fixed warn on empty values

### DIFF
--- a/src/components/LogoSearchForm.jsx
+++ b/src/components/LogoSearchForm.jsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useEffect, useRef } from "react";
 
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
@@ -46,11 +47,22 @@ const LogoSearchForm = (props) => {
     ...other
   } = props;
   const { t } = useTranslation();
+  const inputRef = useRef(null);
 
   const [innerValue, setInnerValue] = React.useState(value);
   const [innerType, setInnerType] = React.useState(type);
   const [innerCount, setInnerCount] = React.useState(count);
   const [innerBarcode, setInnerBarcode] = React.useState(barcode);
+
+  const renderLabelFilter = ["label", "category", "packaging"].includes(
+    innerType
+  );
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [innerValue]);
 
   React.useLayoutEffect(() => {
     setInnerValue(value);
@@ -84,7 +96,7 @@ const LogoSearchForm = (props) => {
             </MenuItem>
           ))}
         </TextField>
-        {["label", "category", "packaging"].includes(innerType) ? (
+        {renderLabelFilter && innerValue !== "" && innerValue !== null ? (
           <LabelFilter
             showKey
             fullWidth
@@ -93,6 +105,7 @@ const LogoSearchForm = (props) => {
             insightType={innerType}
             label={t("logos.value")}
             size="small"
+            inputRef={inputRef}
           />
         ) : (
           <TextField

--- a/src/components/LogoSearchForm.jsx
+++ b/src/components/LogoSearchForm.jsx
@@ -86,7 +86,7 @@ const LogoSearchForm = (props) => {
         </TextField>
         {["label", "category", "packaging"].includes(innerType) ? (
           <LabelFilter
-            showKey={false}
+            showKey
             fullWidth
             value={innerValue}
             onChange={setInnerValue}

--- a/src/components/LogoSearchForm.jsx
+++ b/src/components/LogoSearchForm.jsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useEffect, useRef } from "react";
 
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
@@ -47,22 +46,11 @@ const LogoSearchForm = (props) => {
     ...other
   } = props;
   const { t } = useTranslation();
-  const inputRef = useRef(null);
 
   const [innerValue, setInnerValue] = React.useState(value);
   const [innerType, setInnerType] = React.useState(type);
   const [innerCount, setInnerCount] = React.useState(count);
   const [innerBarcode, setInnerBarcode] = React.useState(barcode);
-
-  const renderLabelFilter = ["label", "category", "packaging"].includes(
-    innerType
-  );
-
-  useEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [innerValue]);
 
   React.useLayoutEffect(() => {
     setInnerValue(value);
@@ -96,16 +84,15 @@ const LogoSearchForm = (props) => {
             </MenuItem>
           ))}
         </TextField>
-        {renderLabelFilter && innerValue !== "" && innerValue !== null ? (
+        {["label", "category", "packaging"].includes(innerType) ? (
           <LabelFilter
-            showKey
+            showKey={false}
             fullWidth
             value={innerValue}
             onChange={setInnerValue}
             insightType={innerType}
             label={t("logos.value")}
             size="small"
-            inputRef={inputRef}
           />
         ) : (
           <TextField

--- a/src/components/QuestionFilter/LabelFilter.tsx
+++ b/src/components/QuestionFilter/LabelFilter.tsx
@@ -120,7 +120,11 @@ const LabelFilter = (props) => {
           {...params}
           {...other}
           helperText={
-            showKey && (innerValue?.key || `⚠️ unknown: "${innerValue}"`)
+            showKey &&
+            (innerValue?.key ||
+              (innerValue !== "" &&
+                innerValue !== null &&
+                `⚠️ unknown: "${innerValue}"`))
           }
         />
       )}


### PR DESCRIPTION
### What
In the ternary operator, i added two && checks that will be true only for non empty string and not null.  This fixed the issue but caused the label filter to lose focus once the user types in a letter. So,additionally, I added a useEffect and useRef hook.  The useEffect hook re-runs everytime the innerValue changes. The useRef hook holds on to the value that the user types and re-focuses on the label filter, this runs everytime the useEffect hook runs.

### Screenshot
<img width="1369" alt="Screen Shot 2023-06-27 at 2 01 47 PM" src="https://github.com/openfoodfacts/hunger-games/assets/102170589/51d7b7ea-69f7-49ee-beb5-b53d31998318">


### Fixes bug(s)
Fix #480 
