### PR TITLE
Fix GitHub pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,12 @@ jobs:
       - name: Deploy
         run: yarn deploy
 
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'dist'
+
       - name: Deploy to github pages 🚀
         if: github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@v4.4.2
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: build # The folder the action should deploy.
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd build;
+cd dist;
 cp index.html 404.html;
 cp index.html insights.html;
 cp index.html questions.html;


### PR DESCRIPTION
- In #663 I forgot to modify the `build.sh` script. This fixes it.
- Now we're directly pushing to GitHub Pages with an action, instead of pushing to the branch.