### PR TITLE
fix: Do not select logos with a value

### DIFF
--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -207,7 +207,8 @@ export default function LogoAnnotation() {
       ...prevState,
       logos: prevState.logos.map((logo, index) => {
         if (logo.annotation_value === null) {
-          logo.selected = true;
+          logo.selected =
+            logo.annotation_type === null && logo.annotation_value === null;
         }
         return logo;
       }),

--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -189,7 +189,9 @@ export default function LogoAnnotation() {
       return {
         ...state,
         logos: state.logos.map((logo) =>
-          shouldBeSet[logo.id]
+          shouldBeSet[logo.id] &&
+          logo.annotation_type === null &&
+          logo.annotation_value === null
             ? {
                 ...logo,
                 selected: newSelectedState,

--- a/src/pages/logos/LogoDeepSearch.jsx
+++ b/src/pages/logos/LogoDeepSearch.jsx
@@ -252,7 +252,9 @@ export default function LogoSearch() {
       ids.forEach((id) => (shouldBeSet[id] = true));
 
       return logos.map((logo) =>
-        shouldBeSet[logo.id]
+        shouldBeSet[logo.id] &&
+        logo.annotation_type === null &&
+        logo.annotation_value === null
           ? {
               ...logo,
               selected: newSelectedState,


### PR DESCRIPTION
Fix slack message

Two related issues with logo annotation:

1. Selecting a range of logos will toggle any logos in the range, regardless of whether or not they already have a value. Since the button is disabled if they have an annotation, they can't be deselected by clicking on them.

**Cause**: Whether or not the logo has an annotation is not checked at this line: https://github.com/openfoodfacts/hunger-games/blob/31327c2d392b7874755482d0663e15aea0b27789/src/pages/logos/LogoAnnotation.jsx#L192

**Solution**: Add `&& logo.annotation_type === null && logo.annotation_value === null`

2. "Select all" have a similar issue, this time only if the annotation type has an empty value.

**Cause**: Only whether or not there is a value is checked at this line: https://github.com/openfoodfacts/hunger-games/blob/31327c2d392b7874755482d0663e15aea0b27789/src/pages/logos/LogoAnnotation.jsx#L207

**Solution**: Add `&& logo.annotation_type === null`