### PR TITLE
ci: remove cron for Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -2,8 +2,6 @@ name: Crowdin
 on:
   push:
     branches: [crowdin-trigger]
-  schedule:
-    - cron: "0 10 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION


### What
- ci: remove cron for Crowdin. The sync is now handled by Crowdin. CRON readds files at the root of crowdin in addition to the more organized sync made by crowdin