### PR TITLE
few bug fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   pages: write
@@ -44,7 +44,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'dist'
+          path: "dist"
 
       - name: Deploy to github pages 🚀
         if: github.ref == 'refs/heads/master'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^4.0.2",
     "husky": "^8.0.2",
-    "prettier": "3.0.0",
+    "prettier": "^2.8.8",
     "pretty-quick": "^3.1.3",
     "typescript": "^4.9.5",
     "vite": "^4.4.2"

--- a/src/components/QuestionFilter/useFilterSearch.js
+++ b/src/components/QuestionFilter/useFilterSearch.js
@@ -35,7 +35,9 @@ export function useFilterSearch() {
 
   const [urlSearchParams, setUrlSearchParams] = useUrlParams(
     DEFAULT_FILTER_URL_PARAMS,
-    { valueTag: ["value_tag", "value"] }
+    {
+      valueTag: ["value_tag", "value"],
+    }
   );
   const exposedParameters = React.useMemo(
     () => convertUrlToParams(urlSearchParams),

--- a/src/components/welcome/Welcome.jsx
+++ b/src/components/welcome/Welcome.jsx
@@ -6,6 +6,9 @@ import { useTheme } from "@mui/material/styles";
 import useControlled from "@mui/utils/useControlled";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import logo from "../../assets/logo.png";
+import logosGame from "../../assets/logosGame.png";
+import questionsGame from "../../assets/questionsGame.png";
+import ecoScoreGame from "../../assets/ecoScoreGame.png";
 
 import Tour from "reactour";
 import {
@@ -76,7 +79,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               flex: "20%",
             }}
-            src={require("../../assets/logo.png")}
+            src={logo}
           />
           <Typography
             variant="h6"
@@ -122,7 +125,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               justifyContent: "center",
             }}
-            src={require("../../assets/questionsGame.png")}
+            src={questionsGame}
           />
         </Box>
       </Box>
@@ -144,7 +147,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               flex: "20%",
             }}
-            src={require("../../assets/logo.png")}
+            src={logo}
           />
           <Typography
             variant="h6"
@@ -175,7 +178,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               justifyContent: "center",
             }}
-            src={require("../../assets/logosGame.png")}
+            src={logosGame}
           />
         </Box>
       </Box>
@@ -197,7 +200,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               flex: "20%",
             }}
-            src={require("../../assets/logo.png")}
+            src={logo}
           />
           <Typography
             variant="h6"
@@ -234,7 +237,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               justifyContent: "center",
             }}
-            src={require("../../assets/ecoScoreGame.png")}
+            src={ecoScoreGame}
           />
         </Box>
       </Box>
@@ -253,7 +256,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               flex: "20%",
             }}
-            src={require("../../assets/logo.png")}
+            src={logo}
           />
           <Typography variant="h6" component="h2" sx={{ marginTop: "8px" }}>
             {t("helper.welcome.page5.title")}
@@ -283,7 +286,7 @@ export const getSteps = ({ t, withSelector, theme }) => [
               height: "auto",
               flex: "20%",
             }}
-            src={require("../../assets/logo.png")}
+            src={logo}
           />
           <Typography variant="h6" component="h2" sx={{ marginTop: "8px" }}>
             {t("helper.welcome.page6.title")}
@@ -331,8 +334,10 @@ const Welcome = (props) => {
 
   const steps = React.useMemo(
     () => getSteps({ t, withSelector: isDesktop, theme }),
-    [t, isDesktop, theme]
+    [t, isDesktop, theme],
   );
+
+  console.log({ steps });
 
   return (
     <>

--- a/src/components/welcome/Welcome.jsx
+++ b/src/components/welcome/Welcome.jsx
@@ -334,7 +334,7 @@ const Welcome = (props) => {
 
   const steps = React.useMemo(
     () => getSteps({ t, withSelector: isDesktop, theme }),
-    [t, isDesktop, theme],
+    [t, isDesktop, theme]
   );
 
   console.log({ steps });

--- a/src/pages/loader/index.jsx
+++ b/src/pages/loader/index.jsx
@@ -6,7 +6,7 @@ export default function Loader() {
     <React.Fragment>
       <CssBaseline />
       <Stack
-        sx={{ bgcolor: "#121212", height: "100vh" }}
+        sx={(theme) => ({ bgcolor: theme.palette.paper, height: "100vh" })}
         justifyContent="center"
         alignItems="center"
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2044,7 +2044,7 @@ __metadata:
     husky: ^8.0.2
     i18next: ^22.4.9
     lodash.isequal: ^4.5.0
-    prettier: 3.0.0
+    prettier: ^2.8.8
     pretty-quick: ^3.1.3
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -2757,12 +2757,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.0":
-  version: 3.0.0
-  resolution: "prettier@npm:3.0.0"
+"prettier@npm:^2.8.8":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
   bin:
-    prettier: bin/prettier.cjs
-  checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
+    prettier: bin-prettier.js
+  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes per commit:

- Impossible to switch pages in the tour (app crashes). The reason being the asset import not supported by viteJs
- pretty-quick does not support prettier v3. So I downgrade prettier to v2 otherwise husky prevent me from commiting(the [GitHub issue](https://github.com/azz/pretty-quick/issues/164#issuecomment-1625533955))
- The loader background was hardcoded with a dark color, leading to a black spinner on a black background in light mode. Here is the before after 🙈

![image](https://github.com/openfoodfacts/hunger-games/assets/45398769/cdbeb9f7-21ff-4243-9098-6e2da944ee9b)
![image](https://github.com/openfoodfacts/hunger-games/assets/45398769/733f847f-ed16-4f5b-af30-77b0d5b07d8e)
