### PR TITLE
fix question fetching

### DIFF
--- a/src/components/welcome/Welcome.jsx
+++ b/src/components/welcome/Welcome.jsx
@@ -337,8 +337,6 @@ const Welcome = (props) => {
     [t, isDesktop, theme]
   );
 
-  console.log({ steps });
-
   return (
     <>
       <Tour

--- a/src/pages/packaging/useBuffer.ts
+++ b/src/pages/packaging/useBuffer.ts
@@ -94,6 +94,5 @@ export const useBuffer = ({
 
   const next = () =>
     setData((prev) => (prev && prev.length > 0 ? prev.slice(1) : prev));
-  console.log(data);
   return [data, next];
 };

--- a/src/pages/questions/QuestionFilter.jsx
+++ b/src/pages/questions/QuestionFilter.jsx
@@ -373,7 +373,7 @@ export const QuestionFilter = () => {
             </TextField>
 
             <FormControlLabel
-              value={innerSortByPopularity}
+              checked={innerSortByPopularity}
               onChange={(event) =>
                 setInnerSortByPopularity(event.target.checked)
               }

--- a/src/pages/questions/store.js
+++ b/src/pages/questions/store.js
@@ -6,6 +6,7 @@ import {
 } from "@reduxjs/toolkit";
 
 import { IS_DEVELOPMENT_MODE } from "../../const";
+import { DEFAULT_FILTER_STATE } from "../../components/QuestionFilter/const";
 import robotoff from "../../robotoff";
 
 import { sleep } from "../../utils";
@@ -16,7 +17,6 @@ export const fetchQuestions = createAsyncThunk(
   "fetchQuestions",
   async (_, thunkApi) => {
     const state = thunkApi.getState();
-    console.log({ state });
     const { data } = await robotoff.questions(
       state.questionBuffer.filterState,
       PAGE_SIZE,
@@ -45,14 +45,7 @@ export const questionBuffer = createSlice({
     answeredQuestions: [],
     fetchCompletted: false,
     numberOfQuestionsAvailable: 0,
-    filterState: {
-      insightType: "brand",
-      brandFilter: "",
-      countryFilter: "",
-      sortByPopularity: false,
-      valueTag: "",
-      predictor: "",
-    },
+    filterState: DEFAULT_FILTER_STATE,
   },
   reducers: {
     updateFilter: (state, action) => {

--- a/src/pages/questions/store.js
+++ b/src/pages/questions/store.js
@@ -16,6 +16,7 @@ export const fetchQuestions = createAsyncThunk(
   "fetchQuestions",
   async (_, thunkApi) => {
     const state = thunkApi.getState();
+    console.log({ state });
     const { data } = await robotoff.questions(
       state.questionBuffer.filterState,
       PAGE_SIZE,
@@ -177,7 +178,7 @@ export const nbOfQuestionsInBufferSelector = createSelector(
 
 export const nextPageSelector = createSelector(
   getSubState,
-  (bufferState) => bufferState.remainingQuestions.length
+  (bufferState) => bufferState.page
 );
 
 export const currentQuestionSelector = createSelector(


### PR DESCRIPTION
If no questions have associated images, the loading was stuck into waiting state do to a wrong selector.

The next page to fetch was accurately computed, but the selector was looking at the wrong property (bad copy past)

Also fix the checkbox "sort by popularity" which was always unselected