### PR TITLE
fix: update OFF_IMAGE_URL

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -3,7 +3,7 @@ export const OFF_URL = "https://world.openfoodfacts.org";
 export const OFF_API_URL = `${OFF_URL}/api/v0`;
 export const OFF_API_URL_V2 = `${OFF_URL}/api/v2`;
 export const OFF_API_URL_V3 = `${OFF_URL}/api/v3`;
-export const OFF_IMAGE_URL = "https://static.openfoodfacts.org/images/products";
+export const OFF_IMAGE_URL = "https://images.openfoodfacts.org/images/products";
 export const OFF_SEARCH = "https://world.openfoodfacts.org/cgi/search.pl";
 export const IS_DEVELOPMENT_MODE = process.env.NODE_ENV === "development";
 export const URL_ORIGINE = IS_DEVELOPMENT_MODE

--- a/src/pages/questions/utils.ts
+++ b/src/pages/questions/utils.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
 
+import { getQuestionSearchParams } from "../../components/QuestionFilter/useFilterSearch";
 import { NO_QUESTION_LEFT, OFF_URL } from "../../const";
-import { reformatValueTag } from "../../utils";
 import externalApi from "../../externalApi";
 import offService from "../../off";
 import robotoff from "../../robotoff";
-import { getQuestionSearchParams } from "../../components/QuestionFilter/useFilterSearch";
+import { reformatValueTag } from "../../utils";
 
 export const ADDITIONAL_INFO_TRANSLATION = {
   brands: "brands",
@@ -31,7 +31,7 @@ export const getImagesUrls = (images, barcode) => {
   const rootImageUrl = offService.getImageUrl(formattedCode);
   return Object.keys(images)
     .filter((key) => !isNaN(Number.parseInt(key)))
-    .map((key) => `${rootImageUrl}/${key}.jpg`);
+    .map((key) => `${rootImageUrl}/${key}.400.jpg`);
 };
 
 // Other questions fetching


### PR DESCRIPTION
images.openfoodfacts.org is the domain to use to serve images: it's hosted by a distinct server dedicated to serving images.