### PR TITLE
Move question filter to TS and  store filter state directly in th url

### DIFF
--- a/src/components/QuestionFilter/useFavorite.ts
+++ b/src/components/QuestionFilter/useFavorite.ts
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { localFavorites } from "../../localeStorageManager";
+
+export const useFavorite = (filterState: any): [boolean, () => void] => {
+  const [isFavorite, setIsFavorite] = React.useState(
+    localFavorites.isSaved(filterState),
+  );
+
+  React.useEffect(() => {
+    setIsFavorite(localFavorites.isSaved(filterState));
+  }, [filterState]);
+
+  const toggleFavorite = React.useCallback(
+    (imageSrc = "", title = "") => {
+      const isSaved = localFavorites.isSaved(filterState);
+
+      if (isSaved) {
+        localFavorites.removeQuestion(filterState);
+      } else {
+        localFavorites.addQuestion(filterState, imageSrc, title);
+      }
+
+      setIsFavorite(!isSaved);
+    },
+    [filterState],
+  );
+  return [isFavorite, toggleFavorite];
+};

--- a/src/hooks/useUrlParams.js
+++ b/src/hooks/useUrlParams.js
@@ -50,7 +50,10 @@ export const convertObjectParamsToUrlParams = (
   const urlParams = new URLSearchParams(window.location.search);
 
   Object.keys(parameters).forEach((key) => {
-    if (JSON.stringify(parameters[key]) !== urlParams.get(key)) {
+    if (
+      JSON.stringify(parameters[key]) !== urlParams.get(key) &&
+      parameters[key] !== ""
+    ) {
       urlParams.set(key, parameters[key]);
     }
   });

--- a/src/pages/questions/useFilterSearch.tsx
+++ b/src/pages/questions/useFilterSearch.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+export function useFilterSearch(
+  queryName: string,
+  defaultValue: string,
+): [string, (val: string) => void] {
+  const [value, setValue] = React.useState<string>(
+    () =>
+      new URLSearchParams(window.location.search).get(queryName) ??
+      defaultValue ??
+      "",
+  );
+
+  function handleUpdate(term: string) {
+    const params = new URLSearchParams(window.location.search);
+    setValue(term);
+    if (term !== "") {
+      params.set(queryName, term);
+    } else {
+      params.delete(queryName);
+    }
+    window.history.pushState(
+      null,
+      "",
+      `${window.location.pathname}?${params.toString()}`,
+    );
+  }
+
+  React.useEffect(() => {
+    // If the default update we use the new default value
+    handleUpdate(
+      new URLSearchParams(window.location.search).get(queryName) ??
+        defaultValue ??
+        "",
+    );
+  }, [defaultValue]);
+
+  return [value, handleUpdate];
+}


### PR DESCRIPTION
I'm moving to the use of `useSearchParams` to manage the filter state.

We have two states: the redux one that manages the robotoff queries, and the url one.

The redux stats is updated when search param is modified and the filter pop-up is not open. Which correspond to:
- a chip is removed
- The page update (first loading, or click on the value button)


I'm starting a general effort to move to TS to spot as much bugs as possible