### PR TITLE
feat: Make ingredient game send answer plus some fixes

### DIFF
--- a/src/off.ts
+++ b/src/off.ts
@@ -138,7 +138,7 @@ const offService = {
       page_size: pageSize.toString(),
       json: "true",
       action: "process",
-      fields,
+      ...(fields === "all" ? {} : { fields }),
     };
     filters.forEach((filterItem, index) => {
       // Expected objects
@@ -168,9 +168,7 @@ const offService = {
       code,
       [`ingredients_text${lang ? `_${lang}` : ""}`]: text,
     });
-    axios.post(`${OFF_URL}/cgi/product_jqm2.pl?${urlParams.toString()}`, {
-      withCredentials: true,
-    });
+    return `${OFF_URL}/cgi/product_jqm2.pl?${urlParams.toString()}`;
   },
 
   async getIngedrientParsing(editionParams: { text: string; lang: string }) {

--- a/src/pages/ingredients/IngeredientDisplay.tsx
+++ b/src/pages/ingredients/IngeredientDisplay.tsx
@@ -49,14 +49,26 @@ function ColorText({
   );
 
   let lastIndex = 0;
+
   return [
     ...flattendIngredients.map((ingredient, i) => {
-      const startIndex = text.indexOf(ingredient.text, lastIndex);
+      // Don't ask me why OFF use this specific character
+      const ingredientText = ingredient.text.replace("‚", ",");
+
+      console.log(ingredientText);
+      console.log(text.slice(lastIndex));
+      const startIndex = text.indexOf(ingredientText, lastIndex);
+      if (startIndex < 0) {
+        return null;
+      }
       const endIndex = startIndex + ingredient.text.length;
 
+      console.log(text.slice(lastIndex, endIndex));
+      console.log("");
       const prefix = text.slice(lastIndex, startIndex);
       const ingredientName = text.slice(startIndex, endIndex);
       lastIndex = endIndex;
+
       return (
         <React.Fragment key={i}>
           <span>{prefix}</span>
@@ -233,10 +245,11 @@ export function IngredientAnotation(props) {
           get parsing
         </LoadingButton>
         <Button
-          onClick={() => {
-            off.setIngedrient({ code, lang, text });
-          }}
+          component="a"
+          target="_blank"
+          href={text && off.setIngedrient({ code, lang, text })}
           variant="contained"
+          disabled={!text}
           color="success"
           fullWidth
         >

--- a/src/pages/ingredients/index.tsx
+++ b/src/pages/ingredients/index.tsx
@@ -16,11 +16,9 @@ import useData from "./useData";
 import ImageAnnotation from "./ImageAnnotation";
 
 function ProductInterface(props) {
-  const {
-    product: { selectedImages, product_name, code },
-    next,
-  } = props;
+  const { product, next } = props;
 
+  const { selectedImages, product_name, code } = product;
   const [imageTab, setImageTab] = React.useState(selectedImages[0].countryCode);
 
   React.useEffect(() => {
@@ -71,6 +69,8 @@ function ProductInterface(props) {
                     <ImageAnnotation
                       fetchDataUrl={fetchDataUrl}
                       code={code as string}
+                      imageLang={countryCode}
+                      offText={product[`ingredients_text_${countryCode}`] ?? ""}
                     />
                   </Stack>
                 </TabPanel>

--- a/src/pages/ingredients/useData.tsx
+++ b/src/pages/ingredients/useData.tsx
@@ -30,6 +30,7 @@ const formatData = (product) => {
     product_name,
     ingredient,
     images,
+    ...other
   } = product;
 
   const baseImageUrl = image_ingredients_url.replace(/ingredients.*/, "");
@@ -64,7 +65,12 @@ const formatData = (product) => {
         geometry: images[key].geometry,
       };
     });
-
+  const ingredientTexts = {};
+  Object.entries(other).forEach(([key, value]) => {
+    if (key.startsWith("ingredient")) {
+      ingredientTexts[key] = value;
+    }
+  });
   return {
     code,
     lang,
@@ -72,6 +78,7 @@ const formatData = (product) => {
     image_ingredients_url,
     product_name,
     ingredient,
+    ...ingredientTexts,
     // images,
   };
 };
@@ -99,8 +106,7 @@ export default function useData(): [any[], () => void, boolean] {
           page,
           pageSize: 25,
           filters: imagesToRead,
-          fields:
-            "code,lang,image_ingredients_url,product_name,ingredient,images",
+          fields: "all",
         });
         if (isValid) {
           const rep = products


### PR DESCRIPTION
Since when sent with JS the API call fails, I replaced it with a link that works 🧑‍🔬

I added some fixes of the ingredient parsing:
- I forgot to handle the case of sub text not existing (`indexOf` returns `-1`)
- for a reason I ignore OFF server seems to replace `,` by a special character very similar

I also added an input that show the current `ingredient_text` of the selected image such that  user can do some cleaning without needing to wait for robotoff