### PR TITLE
feat: deeplinking in eco-score page by country

### DIFF
--- a/src/pages/eco-score/index.tsx
+++ b/src/pages/eco-score/index.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_FILTER_STATE } from "../../components/QuestionFilter/const";
 import { useTranslation } from "react-i18next";
 import { capitaliseName } from "../../utils";
 import Loader from "../loader";
+import { useSearchParams } from "react-router-dom";
 
 const ecoScoreCards = [
   {
@@ -166,7 +167,12 @@ export const countryNames = [
 
 export default function EcoScore() {
   const { t } = useTranslation();
-  const [selectedCountry, setSelectedCountry] = React.useState(countryNames[0]);
+  const [searchParams, setSearchParams]= useSearchParams();
+  const [selectedCountry, setSelectedCountry] = React.useState(searchParams.get('cc') || countryNames[0]);
+
+  React.useEffect(()=>{
+    setSearchParams({'cc':selectedCountry})
+  }, [selectedCountry])
 
   return (
     <React.Suspense fallback={<Loader />}>


### PR DESCRIPTION
### What

Added deeplinking in eco-score page.
Used `useSearchParams` to navigate to specific **country** param.
 
### Screenshot
![openfoodfacts hungergames ecosc-re deeplinking](https://github.com/openfoodfacts/hunger-games/assets/63046396/7ecf33ac-04dd-4729-a13f-fa51bb011b8f)



### Fixes bug(s)
#879 
