### PR TITLE
feat: add country list in settings page, using it as default country in eco-score

### DIFF
--- a/src/localeStorageManager.ts
+++ b/src/localeStorageManager.ts
@@ -16,6 +16,7 @@ const STORAGE_KEY = "hunger-game-settings";
 
 export const localSettingsKeys = {
   language: "lang",
+  country: "country",
   colorMode: "colorMode",
   isDevMode: "devMode",
   visiblePages: "visiblePages",

--- a/src/pages/eco-score/index.tsx
+++ b/src/pages/eco-score/index.tsx
@@ -199,7 +199,7 @@ export default function EcoScore() {
         >
           {countryNames.map((country) => (
             <MenuItem value={country.id} key={country.id}>
-              {capitaliseName(country.id)}
+              {country.label}
             </MenuItem>
           ))}
         </TextField>

--- a/src/pages/eco-score/index.tsx
+++ b/src/pages/eco-score/index.tsx
@@ -11,7 +11,6 @@ import SmallQuestionCard from "../../components/SmallQuestionCard";
 import Opportunities from "../../components/Opportunities";
 import { DEFAULT_FILTER_STATE } from "../../components/QuestionFilter/const";
 import { useTranslation } from "react-i18next";
-import { capitaliseName } from "../../utils";
 import Loader from "../loader";
 import { useSearchParams } from "react-router-dom";
 import { localSettings } from "../../localeStorageManager";

--- a/src/pages/eco-score/index.tsx
+++ b/src/pages/eco-score/index.tsx
@@ -157,7 +157,7 @@ export default function EcoScore() {
   const localData= localSettings.fetch();
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedCountry, setSelectedCountry] = React.useState(
-    searchParams.get("cc") || localData['country'] || countryNames[0],
+    searchParams.get("cc") || localData['country'] || countryNames[81].id,
   );
 
   React.useEffect(() => {

--- a/src/pages/eco-score/index.tsx
+++ b/src/pages/eco-score/index.tsx
@@ -157,7 +157,7 @@ export default function EcoScore() {
   const localData= localSettings.fetch();
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedCountry, setSelectedCountry] = React.useState(
-    searchParams.get("cc") || localData['country'] || countryNames[81].id,
+    searchParams.get("cc") || localData['country'] || "en:france",
   );
 
   React.useEffect(() => {

--- a/src/pages/eco-score/index.tsx
+++ b/src/pages/eco-score/index.tsx
@@ -14,6 +14,8 @@ import { useTranslation } from "react-i18next";
 import { capitaliseName } from "../../utils";
 import Loader from "../loader";
 import { useSearchParams } from "react-router-dom";
+import { localSettings } from "../../localeStorageManager";
+import countryNames from "../../assets/countries.json";
 
 const ecoScoreCards = [
   {
@@ -148,33 +150,19 @@ const ecoScoreCards = [
   },
 ];
 
-export const countryNames = [
-  "en:belgium",
-  "en:denmark",
-  "en:france",
-  "en:germany",
-  "en:italy",
-  "en:netherlands",
-  "en:portugal",
-  "en:spain",
-  "en:sweden",
-  "en:switzerland",
-  "en:united-states",
-  "en:canada",
-  "en:australia",
-  "en:united-kingdom",
-];
+
 
 export default function EcoScore() {
   const { t } = useTranslation();
+  const localData= localSettings.fetch();
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedCountry, setSelectedCountry] = React.useState(
-    searchParams.get("cc") || countryNames[0],
+    searchParams.get("cc") || localData['country'] || countryNames[0],
   );
 
   React.useEffect(() => {
     setSearchParams({ cc: selectedCountry });
-  }, [selectedCountry]);
+  }, [selectedCountry, searchParams]);
 
   return (
     <React.Suspense fallback={<Loader />}>
@@ -210,8 +198,8 @@ export default function EcoScore() {
           sx={{ width: 200 }}
         >
           {countryNames.map((country) => (
-            <MenuItem value={country} key={country}>
-              {capitaliseName(country)}
+            <MenuItem value={country.id} key={country.id}>
+              {capitaliseName(country.id)}
             </MenuItem>
           ))}
         </TextField>

--- a/src/pages/settings/index.jsx
+++ b/src/pages/settings/index.jsx
@@ -22,15 +22,18 @@ import DevModeContext from "../../contexts/devMode";
 import ColorModeContext from "../../contexts/colorMode";
 import { localSettings, localSettingsKeys } from "../../localeStorageManager";
 import FooterWithLinks from "../../components/Footer";
+import countryNames  from "../../assets/countries.json";
+import { capitaliseName } from "../../utils";
 
 export default function Settings() {
   const { t, i18n } = useTranslation();
   const theme = useTheme();
   const colorMode = React.useContext(ColorModeContext);
-
+  const localData= localSettings.fetch();
   const [language, setLanguage] = React.useState(i18n.language);
   const { devMode, setDevMode, visiblePages, setVisiblePages } =
     React.useContext(DevModeContext);
+  const [selectedCountry, setSelectedCountry]= React.useState(localData['country'])
 
   const handleDevModeChange = (event) => {
     localSettings.update(localSettingsKeys.isDevMode, event.target.checked);
@@ -52,6 +55,11 @@ export default function Settings() {
     setLanguage(e.target.value);
   };
 
+  const handleCountryChange= (e)=>{
+    setSelectedCountry(e.target.value);
+    localSettings.update(localSettingsKeys.country, e.target.value)
+  }
+
   return (
     <React.Suspense fallback={<Loader />}>
       <Stack sx={{ my: 5, mx: 2, alignItems: "flex-start" }} spacing={4}>
@@ -68,6 +76,19 @@ export default function Settings() {
           {Object.keys(messages).map((lang) => (
             <MenuItem key={lang} value={lang}>
               {lang.toUpperCase()}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          select
+          label={t("eco-score.countryLabel")}
+          value={selectedCountry}
+          onChange={handleCountryChange}
+          sx={{ width: 200 }}
+        >
+          {countryNames.map((country) => (
+            <MenuItem value={country.id} key={country.id}>
+              {capitaliseName(country.id)}
             </MenuItem>
           ))}
         </TextField>

--- a/src/pages/settings/index.jsx
+++ b/src/pages/settings/index.jsx
@@ -23,7 +23,6 @@ import ColorModeContext from "../../contexts/colorMode";
 import { localSettings, localSettingsKeys } from "../../localeStorageManager";
 import FooterWithLinks from "../../components/Footer";
 import countryNames  from "../../assets/countries.json";
-import { capitaliseName } from "../../utils";
 
 export default function Settings() {
   const { t, i18n } = useTranslation();

--- a/src/pages/settings/index.jsx
+++ b/src/pages/settings/index.jsx
@@ -29,11 +29,10 @@ export default function Settings() {
   const { t, i18n } = useTranslation();
   const theme = useTheme();
   const colorMode = React.useContext(ColorModeContext);
-  const localData= localSettings.fetch();
   const [language, setLanguage] = React.useState(i18n.language);
   const { devMode, setDevMode, visiblePages, setVisiblePages } =
     React.useContext(DevModeContext);
-  const [selectedCountry, setSelectedCountry]= React.useState(localData['country'])
+  const [selectedCountry, setSelectedCountry]= React.useState(() => localSettings.fetch()['country'])
 
   const handleDevModeChange = (event) => {
     localSettings.update(localSettingsKeys.isDevMode, event.target.checked);

--- a/src/pages/settings/index.jsx
+++ b/src/pages/settings/index.jsx
@@ -87,7 +87,7 @@ export default function Settings() {
         >
           {countryNames.map((country) => (
             <MenuItem value={country.id} key={country.id}>
-              {capitaliseName(country.id)}
+              {country.label}
             </MenuItem>
           ))}
         </TextField>


### PR DESCRIPTION
…in eco-score

### What
Add country drop-down in settings page using `countries.json`.
Settings it as default in `eco-score` page.

### Screenshot
![image](https://github.com/openfoodfacts/hunger-games/assets/63046396/17f156fc-87e7-4e44-85bf-3a3b8d9d91e2)


### Fixes bug(s)

Fix #887 