### PR TITLE
fix: use images.openfoodfacts.org to serve images

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -4,7 +4,7 @@ export const OFF_URL = `https://world.${OFF_DOMAIN}`;
 export const OFF_API_URL = `${OFF_URL}/api/v0`;
 export const OFF_API_URL_V2 = `${OFF_URL}/api/v2`;
 export const OFF_API_URL_V3 = `${OFF_URL}/api/v3`;
-export const OFF_IMAGE_URL = `https://static.${OFF_DOMAIN}/images/products`;
+export const OFF_IMAGE_URL = `https://images.${OFF_DOMAIN}/images/products`;
 export const OFF_SEARCH = `${OFF_URL}/cgi/search.pl`;
 export const OFF_SEARCH_A_LISIOUS =
   "https://search.openfoodfacts.org/autocomplete";


### PR DESCRIPTION
We shouldn't use static.openfoodfacts.org anymore, all images should use images.openfoodfacts.org (they're routed to another server that serves only images).