### PR TITLE
fix: Prevent global country update to go back to home page

### DIFF
--- a/src/components/Footer/DownloadOpenFoodFacts.jsx
+++ b/src/components/Footer/DownloadOpenFoodFacts.jsx
@@ -46,7 +46,7 @@ export default function DownloadOpenFoodFacts() {
       {footerLinks.map((link) => {
         return (
           <FooterButtons
-            key={link.title}
+            key={link.url}
             title={t(`footer.${link.titleKey}.title`)}
             subTitle={t(`footer.${link.titleKey}.subtitle`)}
             icon={link.icon}

--- a/src/contexts/CountryProvider/CountryProvider.tsx
+++ b/src/contexts/CountryProvider/CountryProvider.tsx
@@ -19,10 +19,11 @@ export function CountryProvider({ children }) {
       }
       setSearchParams((prev) => {
         prev.set("country", newCountry);
+
         return prev;
       });
     },
-    [],
+    [setSearchParams],
   );
 
   const value = React.useMemo(() => {

--- a/src/pages/ingredients/IngeredientDisplay.tsx
+++ b/src/pages/ingredients/IngeredientDisplay.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";


### PR DESCRIPTION
It seems that the `setSearchParams` is not like React setters. It needs to be in the dependencies of the callback. Otherwise it will update the serachParams of the first url
