### PR TITLE
fix: Nutrition Game - Prevent missing entries in submission

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -323,6 +323,7 @@
     "validate_serving": "Validate (serving)",
     "skip": "Skip",
     "invalid_image": "Invalid image",
+    "missingValues": "It seems that some inputs are empty for nutriments OFF already knows. Either fill those inputs with appropriate value, or put a \"-\" to indicate that the value is not available.",
     "pictures": {
       "picture_date": "Photo uploaded",
       "selected_as_nutrients": "Selected as nutriment image ✅",      

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -323,6 +323,7 @@
     "validate_serving": "Validate (serving)",
     "skip": "Skip",
     "invalid_image": "Invalid image",
+    "missingValues": "It seems that some inputs are empty for nutriments OFF already knows. Either fill those inputs with appropriate value, or put a \"-\" to indicate that the value is not available.",
     "pictures": {
       "picture_date": "Photo uploaded",
       "selected_as_nutrients": "Selected as nutriment image ✅",      

--- a/src/pages/nutrition/preventDataLost.ts
+++ b/src/pages/nutrition/preventDataLost.ts
@@ -1,0 +1,41 @@
+import { NutrimentPrediction } from "./insight.types";
+
+function hasValue(v: Pick<NutrimentPrediction, "value" | "unit">) {
+  return v && v.value !== null && v.value !== undefined && v.value !== "";
+}
+export function doesNotRemoveData({
+  nutrimentId,
+  values,
+  nutriments,
+  category,
+}: {
+  nutrimentId: string;
+  values: Record<string, Pick<NutrimentPrediction, "value" | "unit">>;
+  nutriments?: any;
+  category: "serving" | "100g";
+}) {
+  if (nutriments === undefined) {
+    return true;
+  }
+  if (hasValue(values[`${nutrimentId}_${category}`])) {
+    // The form has value for this nutrient
+    return true;
+  }
+  if (
+    nutriments?.[`${nutrimentId}_serving`] == null &&
+    nutriments?.[`${nutrimentId}_100g`] == null
+  ) {
+    // OFF does not have value for this nutrient.
+    // We check 100g and serving, to avoid validating empty serving if 100g are defined.
+    return true;
+  }
+
+  // Exceptions for sodium if we have value for the sodium or the inverse
+  if (nutrimentId === "sodium" && hasValue(values[`salt_${category}`])) {
+    return true; // no sodium, but salt
+  }
+  if (nutrimentId === "salt" && hasValue(values[`sodium_${category}`])) {
+    return true; // no salt but sodium
+  }
+  return false;
+}


### PR DESCRIPTION
We enforce all fields to be filled.

Special case for salt and sodium, because OFF deduces one from the other


![image](https://github.com/user-attachments/assets/be6d0862-fbe6-4259-8042-6f37c3e75ed1)
