### PR TITLE
fix(#740): change the id from en:united-kingdom to en:uk

### DIFF
--- a/src/assets/countries.json
+++ b/src/assets/countries.json
@@ -1405,7 +1405,7 @@
     "countryCode": "ae"
   },
   {
-    "id": "en:united-kingdom",
+    "id": "en:uk",
     "label": "United Kingdom",
     "languageCode": "en",
     "countryCode": "uk"


### PR DESCRIPTION
It seems that this piece of code is missing in the final version