### PR TITLE
Potential fix for code scanning alert no. 7: Client-side URL redirect

### DIFF
--- a/src/localeStorageManager.ts
+++ b/src/localeStorageManager.ts
@@ -97,9 +97,14 @@ export const getLang = () => {
 
   const urlParams = new URLSearchParams(window.location.search);
   const urlLanguage = urlParams.has("language") && urlParams.get("language");
+  const supportedLanguages = ["en", "fr", "es", "de", "it"]; // Add all supported languages here
+
+  const validatedLanguage = supportedLanguages.includes(urlLanguage)
+    ? urlLanguage
+    : null;
 
   return (
-    urlLanguage ||
+    validatedLanguage ||
     settings[localSettingsKeys.language] ||
     // @ts-expect-error Property 'userLanguage' does not exist on type 'Navigator'.
     (navigator.language || navigator.userLanguage).split("-")[0]

--- a/src/off.ts
+++ b/src/off.ts
@@ -88,9 +88,10 @@ const offService = {
 
   getProductUrl(barcode) {
     const lang = getLang();
+    const sanitizedBarcode = encodeURIComponent(barcode); // Ensure barcode is safe
     return `https://world${
       lang === "en" ? "" : "-" + lang
-    }.${OFF_DOMAIN}/product/${barcode}`;
+    }.${OFF_DOMAIN}/product/${sanitizedBarcode}`;
   },
 
   getProductEditUrl(barcode) {

--- a/src/pages/ingredients/index.tsx
+++ b/src/pages/ingredients/index.tsx
@@ -45,7 +45,7 @@ function ProductInterface(props) {
       <Typography variant="h6">
         {product_name || "No product name"} (scan: {scans_n})
         <br />
-        <a href={off.getProductUrl(code)}>{code}</a>
+        <a href={off.getProductUrl(code)} rel="noopener noreferrer">{code}</a>
       </Typography>
       <Stack direction="column">
         {selectedImages?.length > 0 && (


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/hunger-games/security/code-scanning/7](https://github.com/openfoodfacts/hunger-games/security/code-scanning/7)

To fix the issue, we need to ensure that the URL constructed in `off.getProductUrl(code)` is safe and does not allow untrusted redirection. This can be achieved by validating the `code` and `language` parameters against a whitelist of allowed values or by encoding them to prevent injection of malicious content. Additionally, we should avoid directly using `window.location.search` without validation.

1. Modify the `getLang` function in `src/localeStorageManager.ts` to validate the `language` parameter against a predefined list of supported languages.
2. Update the `getProductUrl` function in `src/off.ts` to validate or sanitize the `code` parameter before constructing the URL.
3. Replace the usage of `off.getProductUrl(code)` in `src/pages/ingredients/index.tsx` with the updated, secure implementation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
