### PR TITLE
Potential fix for code scanning alert no. 4: Client-side URL redirect

### DIFF
--- a/src/localeStorageManager.ts
+++ b/src/localeStorageManager.ts
@@ -97,9 +97,10 @@ export const getLang = () => {
 
   const urlParams = new URLSearchParams(window.location.search);
   const urlLanguage = urlParams.has("language") && urlParams.get("language");
+  const allowedLanguages = ["en", "fr", "es", "de", "it"]; // Add allowed languages here
 
   return (
-    urlLanguage ||
+    (urlLanguage && allowedLanguages.includes(urlLanguage) ? urlLanguage : null) ||
     settings[localSettingsKeys.language] ||
     // @ts-expect-error Property 'userLanguage' does not exist on type 'Navigator'.
     (navigator.language || navigator.userLanguage).split("-")[0]

--- a/src/off.ts
+++ b/src/off.ts
@@ -95,6 +95,10 @@ const offService = {
 
   getProductEditUrl(barcode) {
     const lang = getLang();
+    const barcodeRegex = /^[0-9A-Za-z]+$/; // Adjust regex to match valid barcode patterns
+    if (!barcodeRegex.test(barcode)) {
+      throw new Error("Invalid barcode format");
+    }
     return `https://world${
       lang === "en" ? "" : "-" + lang
     }.${OFF_DOMAIN}/cgi/product.pl?type=edit&code=${barcode}`;


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/hunger-games/security/code-scanning/4](https://github.com/openfoodfacts/hunger-games/security/code-scanning/4)

To fix the issue, we need to validate and sanitize the `code` parameter before using it to construct the URL in `off.getProductEditUrl`. Additionally, we should ensure that the `language` parameter extracted from `window.location.search` is validated against a whitelist of allowed values. This will prevent attackers from injecting malicious data into the constructed URL.

The best approach is to:
1. Introduce a whitelist of allowed languages and validate the `language` parameter in `getLang`.
2. Validate the `code` parameter in `off.getProductEditUrl` to ensure it conforms to expected patterns (e.g., alphanumeric or specific barcode format).
3. Reject or sanitize any invalid input before constructing the URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
