### PR TITLE
fixed: country filter on questions

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -76,9 +76,7 @@ const robotoff = {
       insight_types: insightType,
       value_tag: valueTag,
       brands: reformatValueTag(brandFilter),
-      countries: countryId2countryCode(
-        countryFilter !== "en:world" ? countryFilter : null,
-      ),
+      countries: countryFilter,
       campaign,
       predictor,
       order_by: sortByPopularity ? "popularity" : "random",


### PR DESCRIPTION
### What

Bug fixed.
We were assuming that we are getting country-Id  from filter. But we are directly geting the country-Code. So, we dont need the conversion which we were doing using "countryId2countryCode" function.

### Screenshot

<img width="457" height="170" alt="Screenshot from 2025-07-14 18-27-13" src="https://github.com/user-attachments/assets/a2b05ef5-c0f2-44a2-842d-eda3eb2c5610" />


### Fixes bug(s)
- #1177 
