### PR TITLE
chore: add Vite client types reference file

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
TypeScript, by default, does not recognize static asset imports as valid modules. To fix this, we need to include include vite/client.
