### PR TITLE
chore: Replace react-router-dom with react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-i18next": "^12.3.1",
     "react-map-interaction": "^2.1.0",
     "react-redux": "^8.1.3",
-    "react-router-dom": "^7.9.5",
+    "react-router": "^7.9.5",
     "react-zoom-pan-pinch": "^2.5.0",
     "reactour": "^1.19.4",
     "redux": "^4.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import CssBaseline from "@mui/material/CssBaseline";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router";
 import { useMatomo } from "@jonkoops/matomo-tracker-react";
 import axios from "axios";
 

--- a/src/components/LogoGrid.jsx
+++ b/src/components/LogoGrid.jsx
@@ -10,7 +10,7 @@ import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import Checkbox from "@mui/material/Checkbox";
 
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { useTranslation } from "react-i18next";
 import EditIcon from "@mui/icons-material/Edit";

--- a/src/components/Opportunities.tsx
+++ b/src/components/Opportunities.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import Typography from "@mui/material/Typography";
 import Card from "@mui/material/Card";

--- a/src/components/ResponsiveAppBar.tsx
+++ b/src/components/ResponsiveAppBar.tsx
@@ -25,7 +25,7 @@ import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
 import DevModeContext from "../contexts/devMode";
 import LoginContext from "../contexts/login";
 import logo from "../assets/logo.png";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { useTranslation } from "react-i18next";
 import WelcomeTour from "./welcome/Welcome";

--- a/src/contexts/CountryProvider/CountryProvider.tsx
+++ b/src/contexts/CountryProvider/CountryProvider.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import useLocalStorageState from "../../utils/useLocalStorageState";
 import CountryContext, { CountryCallback } from "./CountryContext";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import countries from "../../assets/countries.json";
 
 const ValidCountryCodes = new Set(countries.map((c) => c.countryCode));

--- a/src/hooks/useSearchParamsState.ts
+++ b/src/hooks/useSearchParamsState.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 export function useSearchParamsState<T>(
   searchName: string,

--- a/src/hooks/useUrlParams.js
+++ b/src/hooks/useUrlParams.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 export const setUrlParams = (parameters, defaultParameters) => {
   const newRelativePathQuery = `${

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import ReactDOM from "react-dom/client";
 
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 
 import "./i18n";
 import App from "./App";

--- a/src/pages/home/homeCards.jsx
+++ b/src/pages/home/homeCards.jsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
 import CardContent from "@mui/material/CardContent";

--- a/src/pages/ingredients/index.tsx
+++ b/src/pages/ingredients/index.tsx
@@ -19,7 +19,7 @@ import off from "../../off";
 import { useTranslation } from "react-i18next";
 import useData from "./useData";
 import ImageAnnotation from "./ImageAnnotation";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { localSettings } from "../../localeStorageManager";
 import countryNames from "../../assets/countries.json";
 import { getCountryId } from "../../utils/getCountryId";

--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -9,7 +9,7 @@ import LoadingButton from "@mui/lab/LoadingButton";
 import { useTheme } from "@mui/material/styles";
 
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import robotoff from "../../robotoff";
 import off from "../../off";
 import LogoGrid from "../../components/LogoGrid";

--- a/src/pages/logos/LogoUpdate.jsx
+++ b/src/pages/logos/LogoUpdate.jsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 import LogoForm from "../../components/LogoForm";
 import robotoff from "../../robotoff";

--- a/src/pages/logosValidator/DashBoard.tsx
+++ b/src/pages/logosValidator/DashBoard.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "@mui/material/styles";
 
 import { LOGOS, DASHBOARD } from "./dashboardDefinition";
 import DashboardCard from "./DashboardCard";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 
 interface TabPanelProps {
   children?: React.ReactNode;

--- a/src/pages/logosValidator/LogoQuestionValidator.jsx
+++ b/src/pages/logosValidator/LogoQuestionValidator.jsx
@@ -14,7 +14,7 @@ import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 import FormControlLabel from "@mui/material/FormControlLabel";
 
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { Provider, useDispatch, useSelector } from "react-redux";
 
 import store, {

--- a/src/pages/questions/QuestionDisplay.jsx
+++ b/src/pages/questions/QuestionDisplay.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import Button from "@mui/material/Button";
 import Badge from "@mui/material/Badge";

--- a/src/pages/questions/QuestionFilter.tsx
+++ b/src/pages/questions/QuestionFilter.tsx
@@ -36,7 +36,7 @@ import {
 } from "../../components/QuestionFilter/const";
 import { capitaliseName } from "../../utils";
 import { filterStateSelector, updateFilter } from "./store";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 const getChipsParams = (filterState, setSearchParams, t) =>
   [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3627,7 +3627,7 @@ __metadata:
     react-i18next: "npm:^12.3.1"
     react-map-interaction: "npm:^2.1.0"
     react-redux: "npm:^8.1.3"
-    react-router-dom: "npm:^7.9.5"
+    react-router: "npm:^7.9.5"
     react-zoom-pan-pinch: "npm:^2.5.0"
     reactour: "npm:^1.19.4"
     redux: "npm:^4.2.0"
@@ -4947,19 +4947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.9.5":
-  version: 7.9.5
-  resolution: "react-router-dom@npm:7.9.5"
-  dependencies:
-    react-router: "npm:7.9.5"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10c0/e54fdfa211e356bd89e3c12b1f89537058357ef21b6a05f55456e0defaab8e77b7495e035ff6999b17a9a2e6f8204d46cf5897fe56e5d3db9458109a014efc4d
-  languageName: node
-  linkType: hard
-
-"react-router@npm:7.9.5":
+"react-router@npm:^7.9.5":
   version: 7.9.5
   resolution: "react-router@npm:7.9.5"
   dependencies:


### PR DESCRIPTION


### What
- Since v7, react-router-dom is just a wrapper for react-router
