### PR TITLE
Fix: anchor tag color adapts to light/dark theme

### DIFF
--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -43,6 +43,8 @@ import {
   useOtherQuestions,
   useFlagImage,
 } from "./utils";
+import { useTheme } from "@mui/material/styles";
+
 
 const ProductInformation = (props) => {
   const { question, productData } = props;
@@ -54,6 +56,7 @@ const ProductInformation = (props) => {
     () => getPageCustomization().questionPage,
   );
   const [flagged, flagImage, deleteFlagImage] = useFlagImage(question?.barcode);
+  const theme = useTheme();
 
   const [
     otherQuestionsState,
@@ -282,7 +285,16 @@ const ProductInformation = (props) => {
                   {t(`questions.${i18nKey}`)}
                 </TableCell>
                 {Array.isArray(value) ? (
-                  <TableCell>
+                  <TableCell
+                    sx={{
+                      "& a": {
+                        color: theme.palette.mode === "dark" ? "white" : "black",
+                        textDecoration: "none",
+                        fontWeight: 500,
+                        "&:hover": { textDecoration: "underline" },
+                      },
+                    }}
+                  >
                     {getLink
                       ? value.map((name, index) => (
                           <React.Fragment key={name}>


### PR DESCRIPTION
### What
Fixed the anchor (<a>) tag color in ProductInformation so it now adapts automatically to the current MUI theme — white in dark mode and black (or theme text color) in light mode.

Improves visual consistency and readability across light/dark themes.

### Screenshot
<img width="1915" height="929" alt="image" src="https://github.com/user-attachments/assets/6d4a4b02-5c97-434d-a5e3-6ab5e84e88a8" />

<img width="1911" height="932" alt="image" src="https://github.com/user-attachments/assets/761569ff-1623-4d2a-a2e6-9a3f7b86089c" />

### Fixes bug(s)
Issue solved: anchor tag color not adapting to dark mode.
the new font colour of categories doesn't work well with dark mode #1241 

### Part of 
UI/Theme consistency improvements.
