### PR TITLE
Fix: resolves issue #1297

### DIFF
--- a/src/pages/insights/InsightsGrid.jsx
+++ b/src/pages/insights/InsightsGrid.jsx
@@ -135,41 +135,36 @@ const InsightGrid = ({ filterState = {}, setFilterState }) => {
         field: "actions",
         type: "actions",
         getActions: (params) => [
-          <React.Fragment>
-            <GridActionsCellItem
-              component="a"
-              href={getProductEditUrl(params.row.barcode)}
-              label={t("insights.edit_product")}
-              icon={
-                <Tooltip title={t("insights.edit_product")}>
-                  <EditIcon />
-                </Tooltip>
-              }
-            />
-            ,
-            <GridActionsCellItem
-              component="a"
-              href={getProductUrl(params.row.barcode)}
-              label={t("insights.view_product")}
-              icon={
-                <Tooltip title={t("insights.view_product")}>
-                  <VisibilityIcon />
-                </Tooltip>
-              }
-            />
-            ,
-            <GridActionsCellItem
-              component="a"
-              href={getLogoCropsByBarcodeUrl(params.row.barcode)}
-              label={t("insights.view_crops_for_this_product")}
-              icon={
-                <Tooltip title={t("insights.view_crops_for_this_product")}>
-                  <VisibilityIcon />
-                </Tooltip>
-              }
-            />
-            ,
-          </React.Fragment>,
+          <GridActionsCellItem
+            component="a"
+            href={getProductEditUrl(params.row.barcode)}
+            label={t("insights.edit_product")}
+            icon={
+              <Tooltip title={t("insights.edit_product")}>
+                <EditIcon />
+              </Tooltip>
+            }
+          />,
+          <GridActionsCellItem
+            component="a"
+            href={getProductUrl(params.row.barcode)}
+            label={t("insights.view_product")}
+            icon={
+              <Tooltip title={t("insights.view_product")}>
+                <VisibilityIcon />
+              </Tooltip>
+            }
+          />,
+          <GridActionsCellItem
+            component="a"
+            href={getLogoCropsByBarcodeUrl(params.row.barcode)}
+            label={t("insights.view_crops_for_this_product")}
+            icon={
+              <Tooltip title={t("insights.view_crops_for_this_product")}>
+                <VisibilityIcon />
+              </Tooltip>
+            }
+          />,
         ],
       },
       {


### PR DESCRIPTION
>> The insights page returns a blank page. This happened because the getActions in InsightsGrid.jsx expected an array but it was receiving a single element. Wrapping it inside an array fixed the issue.

### Fix 1297
- This pull request fixes the bug of insights page not loading in the browser.

### Screenshot
Before: 
<img width="1919" height="958" alt="image" src="https://github.com/user-attachments/assets/31e1a266-b562-463a-bfb3-afc08a6aa61c" />

After: 
<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/b996f395-58ef-439a-b463-3898c9638a94" />


### Fixes bug(s)
- #1297 Loads the Insights page properly: https://hunger.openfoodfacts.org/insights
