### PR TITLE
Fix: resolves issue #1296

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -215,9 +215,8 @@ const robotoff = {
   },
 
   getLogosImages(logoIds: string[]) {
-    const params = new URLSearchParams({
-      logo_ids: logoIds.join(","),
-    });
+    const params = new URLSearchParams();
+    logoIds.forEach((id) => params.append("logo_ids", id));
 
     return axios.get(`${ROBOTOFF_API_URL}/images/logos?${params.toString()}`);
   },


### PR DESCRIPTION
 The /logos page is not loading properly as /logos?logo_ids=4289009%2C5413042 returns 404 bad request. This happened as the backend expects it to be in the form /logos?logo_ids=4289009%2Clogo_ids=5413042. The getLogosImages() was returning request status of 400. Changing the api request params format from frontend solves the issue

### What
- Fix #1296 I have made changes in the query params format that has been send with the /logos request. Changed the src/robotoff.ts file,  getLogosImages() now fetches the logos properly

### Screenshot
Before : 
<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/153ee79d-8ac6-4998-acf7-d3a0eec26d7f" />

After:
<img width="1905" height="1013" alt="image" src="https://github.com/user-attachments/assets/ae48a6fb-0587-4ff0-9de1-991303fa89f5" />

### Fixes bug(s)
- Fix #1296 , Error 400 on the logos game

### Part of 
- #1296 
