### PR TITLE
fix(appbar): resolve menu not showing at md breakpoint(#1243)

### DIFF
--- a/src/components/ResponsiveAppBar.tsx
+++ b/src/components/ResponsiveAppBar.tsx
@@ -239,7 +239,7 @@ const ResponsiveAppBar = () => {
                 open={Boolean(anchorElNav)}
                 onClose={handleCloseNavMenu}
                 sx={{
-                  display: { xs: "block", md: "none" },
+                  display: { xs: "block", lg: "none" },
                 }}
               >
                 {displayedPages.map((page) => {


### PR DESCRIPTION
### What
- Fix #1243: The mobile menu was hidden at the md breakpoint due to a mismatch between the Box visibility (xs-lg) and Menu visibility (xs-md).
Updated Menu display to match Box visibility breakpoints.

### Fixes bug(s)
- #1243 Now menu will be shown at all width
