### PR TITLE
fix: issue 1343 Increasing number of Images breaks the UI of questions page

### DIFF
--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -6,7 +6,6 @@ import Divider from "@mui/material/Divider";
 import Checkbox from "@mui/material/Checkbox";
 import Typography from "@mui/material/Typography";
 import FormControlLabel from "@mui/material/FormControlLabel";
-import Grid from "@mui/material/Grid";
 import EditIcon from "@mui/icons-material/Edit";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import Table from "@mui/material/Table";
@@ -39,7 +38,6 @@ import {
 import useQuestions from "../../hooks/useQuestions";
 import { useProductData } from "../../hooks/useProduct";
 import { useTheme } from "@mui/material/styles";
-import UserData from "./UserData";
 
 const ProductInformation = () => {
   const { t } = useTranslation();
@@ -68,53 +66,40 @@ const ProductInformation = () => {
   return (
     <Box>
       {/* Main information about the product */}
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          flexWrap: "wrap", // optional
-          gap: 2,
-          my: 1,
-        }}
+      <Typography>{productData?.productName}</Typography>
+      <Button
+        size="small"
+        component={Link}
+        target="_blank"
+        href={offService.getProductUrl(question.barcode)}
+        variant="outlined"
+        startIcon={<VisibilityIcon />}
+        sx={{ minWidth: 100 }}
       >
-        <Typography>{productData?.productName}</Typography>
-        <Button
-          size="small"
-          component={Link}
-          target="_blank"
-          href={offService.getProductUrl(question.barcode)}
-          variant="outlined"
-          startIcon={<VisibilityIcon />}
-          sx={{ minWidth: 100 }}
-        >
-          {t("questions.view")}
-        </Button>
-        <Button
-          size="small"
-          component={Link}
-          target="_blank"
-          href={offService.getProductEditUrl(question.barcode)}
-          variant="contained"
-          startIcon={<EditIcon />}
-          sx={{ ml: 2, minWidth: 100 }}
-        >
-          {t("questions.edit")}
-        </Button>
-        <Button
-          size="small"
-          component={Link}
-          target="_blank"
-          href={offService.getLogoCropsByBarcodeUrl(question.barcode)}
-          variant="contained"
-          startIcon={<EditIcon />}
-          sx={{ ml: 2, minWidth: 100 }}
-        >
-          {t("insights.view_crops_for_this_product")}
-        </Button>
-        <Grid item xs="auto" md="auto" sx={{ py: 1 }}>
-          <UserData />
-        </Grid>
-      </Box>
+        {t("questions.view")}
+      </Button>
+      <Button
+        size="small"
+        component={Link}
+        target="_blank"
+        href={offService.getProductEditUrl(question.barcode)}
+        variant="contained"
+        startIcon={<EditIcon />}
+        sx={{ ml: 2, minWidth: 100 }}
+      >
+        {t("questions.edit")}
+      </Button>
+      <Button
+        size="small"
+        component={Link}
+        target="_blank"
+        href={offService.getLogoCropsByBarcodeUrl(question.barcode)}
+        variant="contained"
+        startIcon={<EditIcon />}
+        sx={{ ml: 2, minWidth: 100 }}
+      >
+        {t("insights.view_crops_for_this_product")}
+      </Button>
       {
         /* Other questions */
 
@@ -140,10 +125,12 @@ const ProductInformation = () => {
         <Box
           sx={{
             display: "grid",
-            gridGap: "20px",
+            width: "100%",
+            gridGap: "30px",
             gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
 
-            backgroundColor: "#201f1ff5",
+            backgroundColor:
+              theme.palette.mode === "dark" ? "#201f1ff5" : "white",
             maxHeight: "32rem",
             overflowY: "scroll",
             ml: "1px",
@@ -151,26 +138,9 @@ const ProductInformation = () => {
             pl: "10px",
             py: "10px",
             borderRadius: "10px",
-
-            /* Scrollbar styles (Chrome, Edge, Safari) */
-            "&::-webkit-scrollbar": {
-              width: "8px",
-            },
-            "&::-webkit-scrollbar-track": {
-              background: "#201f1f",
-              borderRadius: "10px",
-            },
-            "&::-webkit-scrollbar-thumb": {
-              backgroundColor: "#888",
-              borderRadius: "10px",
-            },
-            "&::-webkit-scrollbar-thumb:hover": {
-              background: "#aaa",
-            },
-
-            /* Firefox */
             scrollbarWidth: "thin",
-            scrollbarColor: "#4e4d4dff #201f1f",
+            scrollbarColor:
+              theme.palette.mode === "dark" ? "#4e4d4dff #201f1f" : "",
           }}
         >
           {getImagesUrls(productData.images, question.barcode).map((src) => (
@@ -218,72 +188,62 @@ const ProductInformation = () => {
 
       {/* Remaining info */}
       <Divider />
-      <div
-        md={{
-          position: "absolute",
-          width: "40rem",
-          left: "0px",
-          top: "99vh",
-          padding: "2rem",
-        }}
-      >
-        <Table size="small">
-          <TableBody
-            sx={{
-              " td, th": { border: "none" },
-              th: { verticalAlign: "top", pr: 0 },
-            }}
-          >
-            {Object.keys(ADDITIONAL_INFO_TRANSLATION).map((infoKey) => {
-              const { i18nKey, translatedKey, getLink } =
-                ADDITIONAL_INFO_TRANSLATION[infoKey];
+      <Table size="small">
+        <TableBody
+          sx={{
+            " td, th": { border: "none" },
+            th: { verticalAlign: "top", pr: 0 },
+          }}
+        >
+          {Object.keys(ADDITIONAL_INFO_TRANSLATION).map((infoKey) => {
+            const { i18nKey, translatedKey, getLink } =
+              ADDITIONAL_INFO_TRANSLATION[infoKey];
 
-              const value =
-                (translatedKey && productData?.[translatedKey]) ??
-                productData?.[infoKey] ??
-                "?";
+            const value =
+              (translatedKey && productData?.[translatedKey]) ??
+              productData?.[infoKey] ??
+              "?";
 
-              return (
-                <TableRow key={infoKey}>
-                  <TableCell component="th" scope="row">
-                    {t(`questions.${i18nKey}`)}
+            return (
+              <TableRow key={infoKey}>
+                <TableCell component="th" scope="row">
+                  {t(`questions.${i18nKey}`)}
+                </TableCell>
+                {Array.isArray(value) ? (
+                  <TableCell
+                    sx={{
+                      "& a": {
+                        color:
+                          theme.palette.mode === "dark" ? "white" : "black",
+                        textDecoration: "none",
+                        fontWeight: 500,
+                        "&:hover": { textDecoration: "underline" },
+                      },
+                    }}
+                  >
+                    {getLink
+                      ? value.map((name, index) => (
+                          <React.Fragment key={name}>
+                            <a
+                              href={getLink(name)}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {name}
+                            </a>
+                            {index < value.length - 1 ? ", " : ""}
+                          </React.Fragment>
+                        ))
+                      : value.join(", ")}
                   </TableCell>
-                  {Array.isArray(value) ? (
-                    <TableCell
-                      sx={{
-                        "& a": {
-                          color:
-                            theme.palette.mode === "dark" ? "white" : "black",
-                          textDecoration: "none",
-                          fontWeight: 500,
-                          "&:hover": { textDecoration: "underline" },
-                        },
-                      }}
-                    >
-                      {getLink
-                        ? value.map((name, index) => (
-                            <React.Fragment key={name}>
-                              <a
-                                href={getLink(name)}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                {name}
-                              </a>
-                              {index < value.length - 1 ? ", " : ""}
-                            </React.Fragment>
-                          ))
-                        : value.join(", ")}
-                    </TableCell>
-                  ) : (
-                    <TableCell>{value}</TableCell>
-                  )}
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </div>
+                ) : (
+                  <TableCell>{value}</TableCell>
+                )}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
       {isDevMode && devCustomization.showDebug && (
         <DebugQuestion insightId={question.insight_id} />
       )}

--- a/src/pages/questions/index.jsx
+++ b/src/pages/questions/index.jsx
@@ -12,7 +12,7 @@ import Grid from "@mui/material/Grid";
 function QuestionsConsumer() {
   return (
     <Grid container spacing={2} p={2}>
-      <Grid item xs={12} md={6}>
+      <Grid item xs={12} md={5}>
         <Stack
           direction="column"
           sx={{
@@ -24,12 +24,12 @@ function QuestionsConsumer() {
           <QuestionDisplay />
         </Stack>
       </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid item xs={12} md={5}>
         <ProductInformation />
       </Grid>
-      {/* <Grid item xs={12} md={2}>
+      <Grid item xs={12} md={2}>
         <UserData />
-      </Grid> */}
+      </Grid>
 
       {/* pre-fetch images of the next question */}
       {/* {nextImages.map((source_image_url) => (


### PR DESCRIPTION
Added a slider to show images one at a time, users can utilise the arrows to see prev and next images.

### What
Fix #1343 The slider will show one image at a time, preserving the page length and thus not breaking the UI.

Added a new file src/components/Slider.tsx
Made changes in src/pages/questions/ProductInformation.jsx

### Screenshot
Before: 
<img width="1918" height="989" alt="image" src="https://github.com/user-attachments/assets/0593ad71-62ae-4a7c-a755-04a67184bf30" />

After:

https://github.com/user-attachments/assets/99c2e085-1095-4944-b08c-f4280ef066d6


### Fixes bug(s)
#1343 UI/UX: Improve the image layout in the questions page
