### PR TITLE
fix: display a human readable in nutrients component message if robotoff is down #1217

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -328,6 +328,7 @@
     "validate_serving": "Validate (serving)",
     "skip": "Skip",
     "invalid_image": "Invalid image",
+    "robotOffPredictionError": "Nutrition information is temporarily unavailable. Please try again in a few minutes.",
     "pictures": {
       "picture_date": "Photo uploaded",
       "selected_as_nutrients": "Selected as nutriment image ✅",
@@ -375,7 +376,8 @@
     "parsing": "Get server understanding",
     "send": "Validate & send",
     "skip": "Skip this product",
-    "getRobotoffPrediciton": "Get predictions from Robotoff"
+    "getRobotoffPrediciton": "Get predictions from Robotoff",
+    "robotOffPredictionError": "Ingredient detection is temporarily unavailable. Please try again in a few minutes."
   },
   "footer": {
     "appStore": {

--- a/src/pages/nutrition/index.tsx
+++ b/src/pages/nutrition/index.tsx
@@ -4,14 +4,18 @@ import { ErrorBoundary } from "../../components/ErrorBoundary";
 import Instructions from "./Instructions";
 import { RobotoffNutrientExtraction } from "../../components/OffWebcomponents";
 import { Box } from "@mui/material";
+import { useRobotoffPredictions } from "./useRobotoffPredictions";
 
 export default function Nutrition() {
+  const { error } = useRobotoffPredictions(false);
+  console.log(error);
   return (
     <React.Suspense>
       <ErrorBoundary>
         <Instructions />
         <Box sx={{ mb: 2, px: 2 }}>
-          <RobotoffNutrientExtraction />
+          {error && error}
+          {!error && <RobotoffNutrientExtraction />}
         </Box>
       </ErrorBoundary>
     </React.Suspense>

--- a/src/pages/nutrition/useRobotoffPredictions.ts
+++ b/src/pages/nutrition/useRobotoffPredictions.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import robotoff from "../../robotoff";
 import { InsightType } from "./insight.types";
 import { useCountry } from "../../contexts/CountryProvider";
-
+import { useTranslation } from "react-i18next";
 export type ProductType = {
   images: Record<string, any>;
   serving_size?: any;
@@ -13,6 +13,8 @@ export type ProductType = {
 export function useRobotoffPredictions(partiallyFilled: boolean) {
   const [isLoading, setIsLoading] = React.useState(false);
   const [count, setCount] = React.useState(0);
+  const [error, setError] = React.useState<null | string>(null);
+  const { t } = useTranslation();
 
   const campaign = partiallyFilled
     ? "incomplete-nutrition"
@@ -41,7 +43,6 @@ export function useRobotoffPredictions(partiallyFilled: boolean) {
     }
     let valid = true;
     setIsLoading(true);
-
     robotoff
       .getInsights(
         "",
@@ -57,7 +58,6 @@ export function useRobotoffPredictions(partiallyFilled: boolean) {
         if (!valid) {
           return;
         }
-
         setCount(data.count);
         setInsights((prev) => {
           if (campaign === prev.campaign) {
@@ -74,8 +74,13 @@ export function useRobotoffPredictions(partiallyFilled: boolean) {
             data: data.insights,
           };
         });
-
         setIsLoading(false);
+        setError(null);
+      })
+      .catch((error) => {
+        if (!valid) return;
+        setIsLoading(false);
+        setError(t("nutrition.robotOffPredictionError"));
       });
 
     return () => {
@@ -116,5 +121,6 @@ export function useRobotoffPredictions(partiallyFilled: boolean) {
     nextItem,
     count,
     product: product === "loading" ? undefined : product,
+    error,
   };
 }


### PR DESCRIPTION
### What
- fixes the issue #1217, added a catch block to handle the error and display it on the nutrients page.

### Screenshot
- Before

![before_image1](https://github.com/user-attachments/assets/955bc1ee-fba3-4b81-a540-ce242cb69f92)

- After

![after_image1](https://github.com/user-attachments/assets/24a303c9-1f8f-4f13-8919-03269fea5803)

### Part of 
- #1217 
