### PR TITLE
Don't display image of previous questions issue fixed #723

### DIFF
--- a/src/pages/questions/QuestionDisplay.tsx
+++ b/src/pages/questions/QuestionDisplay.tsx
@@ -101,8 +101,8 @@ export default function QuestionDisplay() {
   );
   const [imageLoaded, setImageLoaded] = React.useState(false);
   React.useEffect(() => {
-  setImageLoaded(false); 
-}, [question?.source_image_url]);
+    setImageLoaded(false);
+  }, [question?.source_image_url]);
   const shortcuts = useKeyboardShortcuts(question, answerQuestion);
 
   if (question === null) {
@@ -196,29 +196,29 @@ export default function QuestionDisplay() {
       >
         {question.source_image_url ? (
           <>
-          {!imageLoaded && (
-    <Box
-      sx={{
-        height: isDesktop ? "100%" : "calc(100% - 24px)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <Loader />
-    </Box>
-  )}
-          <ZoomableImage
-            src={question.source_image_url}
-            srcFull={getFullSizeImage(question.source_image_url)}
-            alt=""
-            onLoad={() => setImageLoaded(true)}
-            style={{
-              height: isDesktop ? "100%" : "calc(100% - 24px)",
-              display: imageLoaded ?"inline-block": "none",
-            }}
-            imageProps={{ style: { maxHeight: "100%", maxWidth: "100%" } }}
-          />
+            {!imageLoaded && (
+              <Box
+                sx={{
+                  height: isDesktop ? "100%" : "calc(100% - 24px)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Loader />
+              </Box>
+            )}
+            <ZoomableImage
+              src={question.source_image_url}
+              srcFull={getFullSizeImage(question.source_image_url)}
+              alt=""
+              onLoad={() => setImageLoaded(true)}
+              style={{
+                height: isDesktop ? "100%" : "calc(100% - 24px)",
+                display: imageLoaded ? "inline-block" : "none",
+              }}
+              imageProps={{ style: { maxHeight: "100%", maxWidth: "100%" } }}
+            />
           </>
         ) : (
           <Typography sx={{ marginTop: 20 }}>Image not found</Typography>


### PR DESCRIPTION
### What
- Added a loading State to display the image only when it is loaded.

### Screenshot


https://github.com/user-attachments/assets/0674514f-53cd-4a66-bc60-76b06f36ce39
 

### Part of 
- #723
