### PR TITLE
fix: 1283 Images section now shows newest images first along with date. 

### DIFF
--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -147,7 +147,6 @@ const ProductInformation = () => {
             .reverse()
             .map((src) => (
               <Box>
-                {src.uploaded_t}
                 <Box
                   item
                   key={src.imageUrl}
@@ -192,6 +191,7 @@ const ProductInformation = () => {
                     </Tooltip>
                   )}
                 </Box>
+                <Typography variant="caption">{src.uploaded_t}</Typography>
               </Box>
             ))}
         </Box>

--- a/src/pages/questions/utils.ts
+++ b/src/pages/questions/utils.ts
@@ -40,15 +40,12 @@ export const getImageId = (src: string) => {
   return Number(imageId);
 };
 
-const getUploadedTime = (data: number) => {
-  const date = new Date(data * 1000).toLocaleDateString(undefined, {
+const getUploadedTime = (data: number) =>
+  new Date(data * 1000).toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
   });
-
-  return date;
-};
 
 export const getImagesUrls = (images?: any, barcode?: any) => {
   if (!images || !barcode) {


### PR DESCRIPTION
Latest images will be shown first depending on their upload time. Uploaded date is shown above each image.

### What
- The newest images are shown first in the list along with the date they were taken on.
### Screenshot
<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/1eb3d9b8-c475-4c86-86f0-e1641bfe36c0" />
<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/c81b1430-f26f-4685-8c5c-be0059595080" />


### Fixes bug(s)
- #1283 
