### PR TITLE
feat: Add predictor value filtering for questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The main goal is: Every Open Food Facts user can annotate products in a few minu
 ### Other projects that Hunger Games is built upon
 
 Hunger Games is built upon the following projects. Contributions to these projects will benefit Hunger Games, and they use the same technologies (JavaScript):
+
 - https://github.com/openfoodfacts/openfoodfacts-js
 - https://github.com/openfoodfacts/openfoodfacts-webcomponents
 

--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -88,7 +88,8 @@
         "country": "country",
         "brand": "brand",
         "popularity": "popularity",
-        "campaign": "camp"
+        "campaign": "camp",
+        "predictor": "predictor"
       },
       "long_label": {
         "type": "Question Type",
@@ -97,12 +98,26 @@
         "brand": "Product Brand",
         "popularity": "Sort by popularity",
         "edit": "",
-        "campaign": "Campaign"
+        "campaign": "Campaign",
+        "predictor": "Predictor (Source)"
       },
       "placeholders": {
         "value": "Value (Fanta, en:organic,...)",
         "brand": "Auchan, Danone, Herta, ...",
-        "campaign": "Annotation campaigns"
+        "campaign": "Annotation campaigns",
+        "predictor": "universal-logo-detector, regex, ..."
+      },
+      "all_predictors": "All predictors",
+      "predictor": {
+        "ridge_model_ml": "Ridge Model ML",
+        "neural": "Neural",
+        "matcher": "Matcher",
+        "google_cloud_vision": "Google Cloud Vision",
+        "regex": "Regex",
+        "flashtext": "FlashText",
+        "nutriscore": "Nutriscore",
+        "universal_logo_detector": "Universal Logo Detector",
+        "ocr": "OCR"
       },
       "actions": {
         "edit": "Edit Filters",

--- a/src/pages/questions/FilterDialog.tsx
+++ b/src/pages/questions/FilterDialog.tsx
@@ -77,6 +77,9 @@ export default function FilterDialog(props: FilterDialogProps) {
   const [innerSortByPopularity, setInnerSortByPopularity] = React.useState(
     globalValues.sorted,
   );
+  const [innerPredictor, setInnerPredictor] = React.useState(
+    globalValues.predictor,
+  );
 
   const resetFilter = React.useCallback(() => {
     setInnerInsightType(globalValues.insightType);
@@ -85,6 +88,7 @@ export default function FilterDialog(props: FilterDialogProps) {
     setInnerBrandFilter(globalValues.brand);
     setInnerCampaign(globalValues.campaign);
     setInnerSortByPopularity(globalValues.sorted);
+    setInnerPredictor(globalValues.predictor);
   }, [globalValues]);
 
   const applyFilter = React.useCallback(() => {
@@ -95,6 +99,7 @@ export default function FilterDialog(props: FilterDialogProps) {
       brand: innerBrandFilter,
       campaign: innerCampaign,
       sorted: innerSortByPopularity,
+      predictor: innerPredictor,
     });
     onClose();
   }, [
@@ -104,6 +109,7 @@ export default function FilterDialog(props: FilterDialogProps) {
     innerBrandFilter,
     innerCampaign,
     innerSortByPopularity,
+    innerPredictor,
     onClose,
   ]);
 
@@ -196,6 +202,46 @@ export default function FilterDialog(props: FilterDialogProps) {
                 {val}
               </MenuItem>
             ))}
+          </TextField>
+
+          <TextField
+            select
+            value={innerPredictor}
+            onChange={(event) => setInnerPredictor(event.target.value)}
+            label={t("questions.filters.long_label.predictor")}
+            placeholder={t("questions.filters.placeholders.predictor")}
+            size="small"
+          >
+            <MenuItem value="">
+              <em>{t("questions.filters.all_predictors")}</em>
+            </MenuItem>
+            <MenuItem value="ridge_model-ml">
+              {t("questions.filters.predictor.ridge_model_ml")}
+            </MenuItem>
+            <MenuItem value="neural">
+              {t("questions.filters.predictor.neural")}
+            </MenuItem>
+            <MenuItem value="matcher">
+              {t("questions.filters.predictor.matcher")}
+            </MenuItem>
+            <MenuItem value="google-could-vision">
+              {t("questions.filters.predictor.google_cloud_vision")}
+            </MenuItem>
+            <MenuItem value="regex">
+              {t("questions.filters.predictor.regex")}
+            </MenuItem>
+            <MenuItem value="flashtext">
+              {t("questions.filters.predictor.flashtext")}
+            </MenuItem>
+            <MenuItem value="nutriscore">
+              {t("questions.filters.predictor.nutriscore")}
+            </MenuItem>
+            <MenuItem value="universal-logo-detector">
+              {t("questions.filters.predictor.universal_logo_detector")}
+            </MenuItem>
+            <MenuItem value="ocr">
+              {t("questions.filters.predictor.ocr")}
+            </MenuItem>
           </TextField>
 
           <FormControlLabel

--- a/src/pages/questions/QuestionFilter.tsx
+++ b/src/pages/questions/QuestionFilter.tsx
@@ -99,6 +99,19 @@ const getChipsParams = (
         });
       },
     },
+    {
+      key: "predictor",
+      display: !!filterState.predictor,
+      label: `${t(
+        "questions.filters.short_label.predictor",
+      )}: ${filterState.predictor}`,
+      onDelete: () => {
+        setSearchParams((prev) => {
+          prev.delete("predictor");
+          return prev;
+        });
+      },
+    },
   ].filter((item) => item.display);
 
 export const QuestionFilter = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,9 +2507,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001718":
-  version: 1.0.30001722
-  resolution: "caniuse-lite@npm:1.0.30001722"
-  checksum: 10/60ad52c891221c894085d450c7308f94768702bed4f0b4b99199e3c3c5926b22d7c7c05f474fcdb484befbd43d1975f8529c8ad8f66770f5c32c5342716ecd0b
+  version: 1.0.30001760
+  resolution: "caniuse-lite@npm:1.0.30001760"
+  checksum: 10/ac5c13d00b946c3ace331d25379ed9d85743b1028aba79ae80402cb128b4b491122585144898fefb836d4d9879c13c717a081ae241a00420cbbc7e1b934ec685
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What
This PR adds the ability to filter questions based on the predictor value (e.g., universal-logo-detector, regex, etc.), allowing users to focus on high-value predictions.

Added a new "Predictor" filter to the questions page that allows users to select from all available predictor types:

- ridge_model-ml
- neural
- matcher
- google-cloud-vision
- regex
- flashtext
- nutriscore
- universal-logo-detector
- ocr

### Changes 
- [FilterDialog.tsx] - Added predictor filter field
- Added [innerPredictor] state to track selected predictor
- Updated [resetFilter] callbacks to include predictor
- Added dropdown menu with all 9 predictor options
- [QuestionFilter.tsx] - Added predictor chip display
- Added predictor filter chip to getChipsParams function
- Displays selected predictor with delete functionality
- Only shows when a predictor is selected
- common.json - Added translations
Short label: "predictor"
Long label: "Predictor (Source)"
Placeholder text with examples
Display names for all 9 predictor types

fixes #427 