### PR TITLE
Fix #1267 Remove misleading instruction about picture date

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -351,7 +351,6 @@
       "open_button": "Open instructions",
       "title": "How to use the interface",
       "chose_between_empty_and_partially_filled": "You can chose between products for which OpenFoodFacts (OFF) has no data about the nutrients. Or product with partially filled nutrient table.",
-      "picture_date_is_display": "The date of the picture is displayed on top of it. Allowing you to check if it's a recent one.",
       "indicate_not_provided_value": "Empty inputs are ignored. If fibers are not present in the table, you can put \"-\" to specify the value is not available.",
       "validate_one_column": "Choose the size it is displayed in the picture. If you have 100g and serving size, please choose 100g because it's a normalized format.",
       "skip_button": "If you don't know how to deal with an image, or you just don't want to do it, press \"skip\". Other user will be able to handle it.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -351,7 +351,6 @@
       "open_button": "Open instructions",
       "title": "How to use the interface",
       "chose_between_empty_and_partially_filled": "You can chose between products for which OpenFoodFacts (OFF) has no data about the nutrients. Or product with partially filled nutrient table.",
-      "picture_date_is_display": "The date of the picture is displayed on top of it. Allowing you to check if it's a recent one.",
       "indicate_not_provided_value": "Empty inputs are ignored. If fibers are not present in the table, you can put \"-\" to specify the value is not available.",
       "validate_one_column": "Choose the size it is displayed in the picture. If you have 100g and serving size, please choose 100g because it's a normalized format.",
       "skip_button": "If you don't know how to deal with an image, or you just don't want to do it, press \"skip\". Other user will be able to handle it.",

--- a/src/pages/nutrition/Instructions.tsx
+++ b/src/pages/nutrition/Instructions.tsx
@@ -46,9 +46,7 @@ export default function Instructions() {
                 "nutrition.instructions.chose_between_empty_and_partially_filled",
               )}
             </Typography>
-            <Typography>
-              {t("nutrition.instructions.picture_date_is_display")}
-            </Typography>
+            
             <Typography>
               {t("nutrition.instructions.validate_one_column")}
             </Typography>


### PR DESCRIPTION
### What
Removed mention of the picture date in instructions

### Changes
- Removed `{t("nutrition.instructions.picture_date_is_display")}` from Instructions.tsx
- Removed the `picture_date_is_display` translation key from `src/i18n/common.json`
- Removed the `picture_date_is_display` translation key from `src/i18n/en.json`


### Part of 

Fix #1267
