### PR TITLE
fix: Fixes issue 1368, added i18n translation for ingredients link in navbar.

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -156,7 +156,8 @@
     "tour": "Show tour",
     "logged_in_user": "Logged as {{userName}}",
     "log_in": "Click to login",
-    "moderation":"Moderation"
+    "moderation":"Moderation",
+    "ingredients":"Ingredients"
   },
   "insights": {
     "insights": "Insights",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -159,7 +159,8 @@
     "tour": "Show tour",
     "logged_in_user": "Logged as {{userName}}",
     "log_in": "Click to login",
-    "moderation":"Moderation"
+    "moderation":"Moderation",
+    "ingredients":"Ingredients"
   },
   "insights": {
     "insights": "Insights",


### PR DESCRIPTION
### What
The navbar link for ingridients now shows "INGREDIENTS". Previously it showed "MENU.INGREDIENTS".

### Screenshot
Before:
<img width="1887" height="1028" alt="image" src="https://github.com/user-attachments/assets/6cd08d4a-0614-47df-b4fa-ba118a8fa7d2" />

After:
<img width="1890" height="1018" alt="image" src="https://github.com/user-attachments/assets/317b7117-5770-4be6-a0fb-1c3ca463a281" />

### Fixes bug(s)
- #1368 