### PR TITLE
feat: Switch Hunger Games image reporting/flagging to Nutri-Patrol #1036

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -17,6 +17,7 @@ export const NO_QUESTION_LEFT = "NO_QUESTION_LEFT";
 export const CORRECT_INSIGHT = 1 as const;
 export const WRONG_INSIGHT = 0 as const;
 export const SKIPPED_INSIGHT = -1 as const;
+export const NUTRI_PATROL_URL = "https://nutripatrol.openfoodfacts.org/flag/image/";
 
 // insight types that do not have an associated value
 export const TYPE_WITHOUT_VALUE = ["packager_code", "qr_code", "no_logo"];

--- a/src/externalApi.ts
+++ b/src/externalApi.ts
@@ -1,11 +1,13 @@
+import { NUTRI_PATROL_URL } from "./const";
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const addImageFlag = (opts: {
-  barcode: string | undefined;
-  imgid: number | undefined;
+  barcode: string;
+  imgid: number;
 }) => {
   const {barcode, imgid} = opts;
   const imgidStr = imgid?.toString() || '';
-  const NutriPatrolURL = 'https://nutripatrol.openfoodfacts.org/flag/image/?'+
+  const NutriPatrolURL = `${NUTRI_PATROL_URL}?` +
   new URLSearchParams({
     barcode: barcode || '',
     image_id: imgidStr || '',

--- a/src/externalApi.ts
+++ b/src/externalApi.ts
@@ -1,11 +1,22 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const addImageFlag = (opts: {
-  barcode: string;
-  imgid: string;
-  url: string;
+  barcode: string | undefined;
+  imgid: number | undefined;
 }) => {
   // TODO: Replace this with NutriPatrol
-  throw new Error("This function is not implemented yet");
+  const {barcode, imgid} = opts;
+  const imgidStr = imgid?.toString() || '';
+  const NutriPatrolURL = 'https://nutripatrol.openfoodfacts.org/flag/image/?'+
+  new URLSearchParams({
+    barcode: barcode || '',
+    image_id: imgidStr || '',
+    source: "web", flavor: "off",
+  }).toString();
+  try {
+    window.open(NutriPatrolURL, '_blank', 'noopener,noreferrer');
+  } catch (error) {
+    throw new Error("Could not open NutriPatrol");
+  }
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/externalApi.ts
+++ b/src/externalApi.ts
@@ -3,7 +3,6 @@ export const addImageFlag = (opts: {
   barcode: string | undefined;
   imgid: number | undefined;
 }) => {
-  // TODO: Replace this with NutriPatrol
   const {barcode, imgid} = opts;
   const imgidStr = imgid?.toString() || '';
   const NutriPatrolURL = 'https://nutripatrol.openfoodfacts.org/flag/image/?'+
@@ -15,7 +14,7 @@ export const addImageFlag = (opts: {
   try {
     window.open(NutriPatrolURL, '_blank', 'noopener,noreferrer');
   } catch (error) {
-    throw new Error("Could not open NutriPatrol");
+    throw new Error("Could not open NutriPatrol, error: " + error);
   }
 };
 

--- a/src/pages/questions/ProductInformation.jsx
+++ b/src/pages/questions/ProductInformation.jsx
@@ -183,7 +183,7 @@ const ProductInformation = () => {
                     <Tooltip title={t("questions.flag")}>
                       <IconButton
                         onClick={() =>
-                          flagImage(src.imageUrl, question.barcode)
+                          flagImage(src.imageUrl)
                         }
                       >
                         <OutlinedFlagIcon />

--- a/src/pages/questions/utils.ts
+++ b/src/pages/questions/utils.ts
@@ -67,7 +67,7 @@ export const useFlagImage = (barcode?: string) => {
   const flagImage = React.useCallback(
     (src: string) => {
       const imgid = getImageId(src);
-      externalApi.addImageFlag({ barcode, imgid, url: src });
+      externalApi.addImageFlag({ barcode, imgid });
       setFlagged((prev) => [...prev, imgid]);
     },
     [barcode],


### PR DESCRIPTION
### What
Added support for flagging the images via -Nutri-Patrol!!
- For now opening a distinct tab to report, later we can switch to sdk once the CORS is enabled!
- Also Nutri-Patrol ensures that user is logged in then only he/she can report.


### Video

https://github.com/user-attachments/assets/c2e3b729-f52c-4599-a652-8324bbdbd6dc



### Fixes bug(s)
- #1036 
