### PR TITLE
refactor(api): modernise annotate body and remove param clamping

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -1,248 +1,238 @@
-  import axios from "axios";
+import axios from "axios";
 
-  import { ROBOTOFF_API_URL } from "./const";
-  import { getLang } from "./localeStorageManager";
-  import { reformatValueTag, removeEmptyKeys } from "./utils";
+import { ROBOTOFF_API_URL } from "./const";
+import { getLang } from "./localeStorageManager";
+import { reformatValueTag, removeEmptyKeys } from "./utils";
 
-  export interface QuestionInterface {
-    barcode: string;
-    insight_id: string;
-    insight_type: string;
-    question: string;
-    source_image_url?: string;
-    ref_image_url?: string;
-    type: string;
-    value: string;
-    value_tag: string;
-  }
+export interface QuestionInterface {
+  barcode: string;
+  insight_id: string;
+  insight_type: string;
+  question: string;
+  source_image_url?: string;
+  ref_image_url?: string;
+  type: string;
+  value: string;
+  value_tag: string;
+}
 
-  export type FilterState = {
-    insightType?: string;
-    brandFilter?: string;
-    country?: string;
-    brand?: string;
-    valueTag?: string;
-    countryFilter?: string;
-    sortByPopularity?: boolean;
-    campaign?: string;
-    predictor?: string;
-    with_image?: boolean;
-    sorted?: string;
-  };
+export type FilterState = {
+  insightType?: string;
+  brandFilter?: string;
+  country?: string;
+  brand?: string;
+  valueTag?: string;
+  countryFilter?: string;
+  sortByPopularity?: boolean;
+  campaign?: string;
+  predictor?: string;
+  with_image?: boolean;
+  sorted?: string;
+};
 
-  type GetQuestionsResponse = { count: number; questions: QuestionInterface[] };
+type GetQuestionsResponse = { count: number; questions: QuestionInterface[] };
 
-  const robotoff = {
+const robotoff = {
   annotate(insightId: string, annotation: -1 | 0 | 1) {
-    // Use URLSearchParams with an object for cleaner, safer code
     const body = new URLSearchParams({
       insight_id: insightId,
       annotation: annotation.toString(),
-      update: '1'
+      update: "1",
     });
 
-    return axios.post(
-      `${ROBOTOFF_API_URL}/insights/annotate`,
-      body,
+    return axios.post(`${ROBOTOFF_API_URL}/insights/annotate`, body, {
+      withCredentials: true,
+    });
+  },
+
+  async questionsByProductCode(code: string) {
+    const result = await axios.get<GetQuestionsResponse>(
+      `${ROBOTOFF_API_URL}/questions/${code}`,
+    );
+
+    return {
+      ...result,
+      data: {
+        ...result.data,
+        // Filter out questions without image
+        questions: result.data.questions.filter((q) => q.source_image_url),
+      },
+    };
+  },
+
+  questions(
+    {
+      insightType,
+      brandFilter,
+      valueTag,
+      countryFilter,
+      sortByPopularity,
+      campaign,
+      predictor,
+      with_image,
+    }: FilterState,
+    count = 10,
+    page = 1,
+  ) {
+    const searchParams = {
+      insight_types: insightType,
+      value_tag: valueTag,
+      brands: reformatValueTag(brandFilter),
+      countries: countryFilter,
+      campaign,
+      predictor,
+      with_image,
+      order_by: sortByPopularity ? "popularity" : "random",
+    };
+
+    const lang = getLang();
+
+    return axios.get<GetQuestionsResponse>(`${ROBOTOFF_API_URL}/questions/`, {
+      params: removeEmptyKeys({ ...searchParams, lang, count, page }),
+    });
+  },
+
+  insightDetail(insight_id: string) {
+    return axios.get(`${ROBOTOFF_API_URL}/insights/detail/${insight_id}`);
+  },
+
+  loadLogo(logoId: string) {
+    return axios.get(`${ROBOTOFF_API_URL}/images/logos/${logoId}`);
+  },
+
+  updateLogo(logoId: string, value: string, type: string) {
+    return axios.put(
+      `${ROBOTOFF_API_URL}/images/logos/${logoId}`,
+      removeEmptyKeys({ value, type }),
       { withCredentials: true },
     );
   },
-    async questionsByProductCode(code: string) {
-      const result = await axios.get<GetQuestionsResponse>(
-        `${ROBOTOFF_API_URL}/questions/${code}`,
-      );
 
-      return {
-        ...result,
-        data: {
-          ...result.data,
-          // Filter out questions without image
-          questions: result.data.questions.filter((q) => q.source_image_url),
-        },
-      };
-    },
+  searchLogos(
+    barcode: string,
+    value: string,
+    type: string,
+    count = 25,
+    random = false,
+  ) {
+    const formattedValue = /^[a-z][a-z]:/.test(value)
+      ? { taxonomy_value: value }
+      : { value };
 
-    questions(
-      {
-        insightType,
-        brandFilter,
-        valueTag,
-        countryFilter,
-        sortByPopularity,
-        campaign,
-        predictor,
-        with_image,
-      }: FilterState,
-      count = 10,
-      page = 1,
-    ) {
+    return axios.get(`${ROBOTOFF_API_URL}/images/logos/search/`, {
+      params: removeEmptyKeys({
+        barcode,
+        type,
+        count,
+        random,
+        ...formattedValue,
+      }),
+    });
+  },
 
+  getLogoAnnotations(logoId: string, index: number, count = 25) {
+    let url = `${ROBOTOFF_API_URL}/ann/search`;
+    if (logoId.length > 0) {
+      url += `/${logoId}`;
+    }
 
-      const searchParams = {
+    return axios.get(url, {
+      params: removeEmptyKeys({
+        index,
+        count,
+      }),
+    });
+  },
+
+  annotateLogos(annotations) {
+    return axios.post(
+      `${ROBOTOFF_API_URL}/images/logos/annotate`,
+      removeEmptyKeys({ annotations }),
+      { withCredentials: true },
+    );
+  },
+
+  getInsights(
+    barcode = "",
+    insightType = "",
+    valueTag = "",
+    annotation = "",
+    page = 1,
+    count = 25,
+    campaigns = "",
+    country = "",
+  ) {
+    let annotated;
+    if (annotation.length && annotation === "not_annotated") {
+      annotated = "0";
+      annotation = "";
+    }
+    return axios.get(`${ROBOTOFF_API_URL}/insights`, {
+      params: removeEmptyKeys({
+        barcode,
         insight_types: insightType,
         value_tag: valueTag,
-        brands: reformatValueTag(brandFilter),
-        countries: countryFilter,
-        campaign,
-        predictor,
-        with_image,
-        order_by: sortByPopularity ? "popularity" : "random",
-      };
+        annotation,
+        page,
+        annotated,
+        count,
+        campaigns,
+        countries: country,
+      }),
+    });
+  },
 
-      const lang = getLang();
+  getUserStatistics(username: string) {
+    return axios.get(`${ROBOTOFF_API_URL}/users/statistics/${username}`);
+  },
 
-      return axios.get<GetQuestionsResponse>(`${ROBOTOFF_API_URL}/questions/`, {
-        //used the safe values here for count & page
-        params: removeEmptyKeys({
-          ...searchParams,
-          lang,
-          count,
-          page,
+  getCroppedImageUrl(
+    imageUrl: string,
+    boundingBox: [number, number, number, number],
+  ) {
+    const [y_min, x_min, y_max, x_max] = boundingBox;
+
+    const params = new URLSearchParams({
+      image_url: imageUrl,
+      y_min: y_min.toString(),
+      x_min: x_min.toString(),
+      y_max: y_max.toString(),
+      x_max: x_max.toString(),
+    });
+
+    return `${ROBOTOFF_API_URL}/images/crop?${params.toString()}`;
+  },
+
+  getLogosImages(logoIds: string[]) {
+    const params = new URLSearchParams();
+    logoIds.forEach((id) => params.append("logo_ids", id));
+
+    return axios.get(`${ROBOTOFF_API_URL}/images/logos?${params.toString()}`);
+  },
+
+  getUnansweredValues({
+    page = 1,
+    countryCode,
+    ...other
+  }: {
+    type: "label" | "brand" | "category";
+    countryCode: string;
+    campaign: string;
+    page?: number;
+    count?: number;
+  }) {
+    return axios.get(
+      `${ROBOTOFF_API_URL}/questions/unanswered/?${Object.entries(
+        removeEmptyKeys({
+          ...other,
+          countries: countryCode,
+          page: page >= 1 ? page : 1,
         }),
-      });
-    },
+      )
+        .map(([key, value]) => `${key}=${value}`)
+        .join("&")}`,
+    );
+  },
+};
 
-    insightDetail(insight_id: string) {
-      return axios.get(`${ROBOTOFF_API_URL}/insights/detail/${insight_id}`);
-    },
-
-    loadLogo(logoId: string) {
-      return axios.get(`${ROBOTOFF_API_URL}/images/logos/${logoId}`);
-    },
-
-    updateLogo(logoId: string, value: string, type: string) {
-      return axios.put(
-        `${ROBOTOFF_API_URL}/images/logos/${logoId}`,
-        removeEmptyKeys({ value, type }),
-        { withCredentials: true },
-      );
-    },
-
-    searchLogos(
-      barcode: string,
-      value: string,
-      type: string,
-      count = 25,
-      random = false,
-    ) {
-      const formattedValue = /^[a-z][a-z]:/.test(value)
-        ? { taxonomy_value: value }
-        : { value };
-
-      return axios.get(`${ROBOTOFF_API_URL}/images/logos/search/`, {
-        params: removeEmptyKeys({
-          barcode,
-          type,
-          count,
-          random,
-          ...formattedValue,
-        }),
-      });
-    },
-
-    getLogoAnnotations(logoId: string, index: number, count = 25) {
-      let url = `${ROBOTOFF_API_URL}/ann/search`;
-      if (logoId.length > 0) {
-        url += `/${logoId}`;
-      }
-
-      return axios.get(url, {
-        params: removeEmptyKeys({
-          index,
-          count,
-        }),
-      });
-    },
-
-    annotateLogos(annotations) {
-      return axios.post(
-        `${ROBOTOFF_API_URL}/images/logos/annotate`,
-        removeEmptyKeys({ annotations }),
-        { withCredentials: true },
-      );
-    },
-
-    getInsights(
-      barcode = "",
-      insightType = "",
-      valueTag = "",
-      annotation = "",
-      page = 1,
-      count = 25,
-      campaigns = "",
-      country = "",
-    ) {
-      let annotated;
-      if (annotation.length && annotation === "not_annotated") {
-        annotated = "0";
-        annotation = "";
-      }
-      return axios.get(`${ROBOTOFF_API_URL}/insights`, {
-        params: removeEmptyKeys({
-          barcode,
-          insight_types: insightType,
-          value_tag: valueTag,
-          annotation,
-          page,
-          annotated,
-          count,
-          campaigns,
-          countries: country,
-        }),
-      });
-    },
-
-    getUserStatistics(username: string) {
-      return axios.get(`${ROBOTOFF_API_URL}/users/statistics/${username}`);
-    },
-
-    getCroppedImageUrl(
-      imageUrl: string,
-      boundingBox: [number, number, number, number],
-    ) {
-      const [y_min, x_min, y_max, x_max] = boundingBox;
-
-      const params = new URLSearchParams({
-        image_url: imageUrl,
-        y_min: y_min.toString(),
-        x_min: x_min.toString(),
-        y_max: y_max.toString(),
-        x_max: x_max.toString(),
-      });
-
-      return `${ROBOTOFF_API_URL}/images/crop?${params.toString()}`;
-    },
-
-    getLogosImages(logoIds: string[]) {
-      const params = new URLSearchParams();
-      logoIds.forEach((id) => params.append("logo_ids", id));
-
-      return axios.get(`${ROBOTOFF_API_URL}/images/logos?${params.toString()}`);
-    },
-
-    getUnansweredValues({
-      page = 1,
-      countryCode,
-      ...other
-    }: {
-      type: "label" | "brand" | "category";
-      countryCode: string;
-      campaign: string;
-      page?: number;
-      count?: number;
-    }) {
-      return axios.get(
-        `${ROBOTOFF_API_URL}/questions/unanswered/?${Object.entries(
-          removeEmptyKeys({
-            ...other,
-            countries: countryCode,
-            page: page >= 1 ? page : 1,
-          }),
-        )
-          .map(([key, value]) => `${key}=${value}`)
-          .join("&")}`,
-      );
-    },
-  };
-
-  export default robotoff;
+export default robotoff;

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -1,236 +1,250 @@
-import axios from "axios";
+  import axios from "axios";
 
-import { ROBOTOFF_API_URL } from "./const";
-import { getLang } from "./localeStorageManager";
-import { reformatValueTag, removeEmptyKeys } from "./utils";
+  import { ROBOTOFF_API_URL } from "./const";
+  import { getLang } from "./localeStorageManager";
+  import { reformatValueTag, removeEmptyKeys } from "./utils";
 
-export interface QuestionInterface {
-  barcode: string;
-  insight_id: string;
-  insight_type: string;
-  question: string;
-  source_image_url?: string;
-  ref_image_url?: string;
-  type: string;
-  value: string;
-  value_tag: string;
-}
+  export interface QuestionInterface {
+    barcode: string;
+    insight_id: string;
+    insight_type: string;
+    question: string;
+    source_image_url?: string;
+    ref_image_url?: string;
+    type: string;
+    value: string;
+    value_tag: string;
+  }
 
-export type FilterState = {
-  insightType?: string;
-  brandFilter?: string;
-  country?: string;
-  brand?: string;
-  valueTag?: string;
-  countryFilter?: string;
-  sortByPopularity?: boolean;
-  campaign?: string;
-  predictor?: string;
-  with_image?: boolean;
-  sorted?: string;
-};
+  export type FilterState = {
+    insightType?: string;
+    brandFilter?: string;
+    country?: string;
+    brand?: string;
+    valueTag?: string;
+    countryFilter?: string;
+    sortByPopularity?: boolean;
+    campaign?: string;
+    predictor?: string;
+    with_image?: boolean;
+    sorted?: string;
+  };
 
-type GetQuestionsResponse = { count: number; questions: QuestionInterface[] };
+  type GetQuestionsResponse = { count: number; questions: QuestionInterface[] };
 
-const robotoff = {
+  const robotoff = {
   annotate(insightId: string, annotation: -1 | 0 | 1) {
+    // Use URLSearchParams with an object for cleaner, safer code
+    const body = new URLSearchParams({
+      insight_id: insightId,
+      annotation: annotation.toString(),
+      update: '1'
+    });
+
     return axios.post(
       `${ROBOTOFF_API_URL}/insights/annotate`,
-      new URLSearchParams(
-        `insight_id=${insightId}&annotation=${annotation}&update=1`,
-      ),
+      body,
       { withCredentials: true },
     );
   },
+    async questionsByProductCode(code: string) {
+      const result = await axios.get<GetQuestionsResponse>(
+        `${ROBOTOFF_API_URL}/questions/${code}`,
+      );
 
-  async questionsByProductCode(code: string) {
-    const result = await axios.get<GetQuestionsResponse>(
-      `${ROBOTOFF_API_URL}/questions/${code}`,
-    );
+      return {
+        ...result,
+        data: {
+          ...result.data,
+          // Filter out questions without image
+          questions: result.data.questions.filter((q) => q.source_image_url),
+        },
+      };
+    },
 
-    return {
-      ...result,
-      data: {
-        ...result.data,
-        // Filter out questions without image
-        questions: result.data.questions.filter((q) => q.source_image_url),
-      },
-    };
-  },
+    questions(
+      {
+        insightType,
+        brandFilter,
+        valueTag,
+        countryFilter,
+        sortByPopularity,
+        campaign,
+        predictor,
+        with_image,
+      }: FilterState,
+      count = 10,
+      page = 1,
+    ) {
+      // EDGE CASE FIX: Ensuring count and page are positive integers
+      const safeCount = Math.max(1, Math.floor(count));
+      const safePage = Math.max(1, Math.floor(page));
 
-  questions(
-    {
-      insightType,
-      brandFilter,
-      valueTag,
-      countryFilter,
-      sortByPopularity,
-      campaign,
-      predictor,
-      with_image,
-    }: FilterState,
-    count = 10,
-    page = 1,
-  ) {
-    const searchParams = {
-      insight_types: insightType,
-      value_tag: valueTag,
-      brands: reformatValueTag(brandFilter),
-      countries: countryFilter,
-      campaign,
-      predictor,
-      with_image,
-      order_by: sortByPopularity ? "popularity" : "random",
-    };
-
-    const lang = getLang();
-
-    return axios.get<GetQuestionsResponse>(`${ROBOTOFF_API_URL}/questions/`, {
-      params: removeEmptyKeys({ ...searchParams, lang, count, page }),
-    });
-  },
-
-  insightDetail(insight_id: string) {
-    return axios.get(`${ROBOTOFF_API_URL}/insights/detail/${insight_id}`);
-  },
-
-  loadLogo(logoId: string) {
-    return axios.get(`${ROBOTOFF_API_URL}/images/logos/${logoId}`);
-  },
-
-  updateLogo(logoId: string, value: string, type: string) {
-    return axios.put(
-      `${ROBOTOFF_API_URL}/images/logos/${logoId}`,
-      removeEmptyKeys({ value, type }),
-      { withCredentials: true },
-    );
-  },
-
-  searchLogos(
-    barcode: string,
-    value: string,
-    type: string,
-    count = 25,
-    random = false,
-  ) {
-    const formattedValue = /^[a-z][a-z]:/.test(value)
-      ? { taxonomy_value: value }
-      : { value };
-
-    return axios.get(`${ROBOTOFF_API_URL}/images/logos/search/`, {
-      params: removeEmptyKeys({
-        barcode,
-        type,
-        count,
-        random,
-        ...formattedValue,
-      }),
-    });
-  },
-
-  getLogoAnnotations(logoId: string, index: number, count = 25) {
-    let url = `${ROBOTOFF_API_URL}/ann/search`;
-    if (logoId.length > 0) {
-      url += `/${logoId}`;
-    }
-
-    return axios.get(url, {
-      params: removeEmptyKeys({
-        index,
-        count,
-      }),
-    });
-  },
-
-  annotateLogos(annotations) {
-    return axios.post(
-      `${ROBOTOFF_API_URL}/images/logos/annotate`,
-      removeEmptyKeys({ annotations }),
-      { withCredentials: true },
-    );
-  },
-
-  getInsights(
-    barcode = "",
-    insightType = "",
-    valueTag = "",
-    annotation = "",
-    page = 1,
-    count = 25,
-    campaigns = "",
-    country = "",
-  ) {
-    let annotated;
-    if (annotation.length && annotation === "not_annotated") {
-      annotated = "0";
-      annotation = "";
-    }
-    return axios.get(`${ROBOTOFF_API_URL}/insights`, {
-      params: removeEmptyKeys({
-        barcode,
+      const searchParams = {
         insight_types: insightType,
         value_tag: valueTag,
-        annotation,
-        page,
-        annotated,
-        count,
-        campaigns,
-        countries: country,
-      }),
-    });
-  },
+        brands: reformatValueTag(brandFilter),
+        countries: countryFilter,
+        campaign,
+        predictor,
+        with_image,
+        order_by: sortByPopularity ? "popularity" : "random",
+      };
 
-  getUserStatistics(username: string) {
-    return axios.get(`${ROBOTOFF_API_URL}/users/statistics/${username}`);
-  },
+      const lang = getLang();
 
-  getCroppedImageUrl(
-    imageUrl: string,
-    boundingBox: [number, number, number, number],
-  ) {
-    const [y_min, x_min, y_max, x_max] = boundingBox;
-
-    const params = new URLSearchParams({
-      image_url: imageUrl,
-      y_min: y_min.toString(),
-      x_min: x_min.toString(),
-      y_max: y_max.toString(),
-      x_max: x_max.toString(),
-    });
-
-    return `${ROBOTOFF_API_URL}/images/crop?${params.toString()}`;
-  },
-
-  getLogosImages(logoIds: string[]) {
-    const params = new URLSearchParams();
-    logoIds.forEach((id) => params.append("logo_ids", id));
-
-    return axios.get(`${ROBOTOFF_API_URL}/images/logos?${params.toString()}`);
-  },
-
-  getUnansweredValues({
-    page = 1,
-    countryCode,
-    ...other
-  }: {
-    type: "label" | "brand" | "category";
-    countryCode: string;
-    campaign: string;
-    page?: number;
-    count?: number;
-  }) {
-    return axios.get(
-      `${ROBOTOFF_API_URL}/questions/unanswered/?${Object.entries(
-        removeEmptyKeys({
-          ...other,
-          countries: countryCode,
-          page: page >= 1 ? page : 1,
+      return axios.get<GetQuestionsResponse>(`${ROBOTOFF_API_URL}/questions/`, {
+        //used the safe values here for count & page
+        params: removeEmptyKeys({
+          ...searchParams,
+          lang,
+          count: safeCount,
+          page: safePage,
         }),
-      )
-        .map(([key, value]) => `${key}=${value}`)
-        .join("&")}`,
-    );
-  },
-};
+      });
+    },
 
-export default robotoff;
+    insightDetail(insight_id: string) {
+      return axios.get(`${ROBOTOFF_API_URL}/insights/detail/${insight_id}`);
+    },
+
+    loadLogo(logoId: string) {
+      return axios.get(`${ROBOTOFF_API_URL}/images/logos/${logoId}`);
+    },
+
+    updateLogo(logoId: string, value: string, type: string) {
+      return axios.put(
+        `${ROBOTOFF_API_URL}/images/logos/${logoId}`,
+        removeEmptyKeys({ value, type }),
+        { withCredentials: true },
+      );
+    },
+
+    searchLogos(
+      barcode: string,
+      value: string,
+      type: string,
+      count = 25,
+      random = false,
+    ) {
+      const formattedValue = /^[a-z][a-z]:/.test(value)
+        ? { taxonomy_value: value }
+        : { value };
+
+      return axios.get(`${ROBOTOFF_API_URL}/images/logos/search/`, {
+        params: removeEmptyKeys({
+          barcode,
+          type,
+          count,
+          random,
+          ...formattedValue,
+        }),
+      });
+    },
+
+    getLogoAnnotations(logoId: string, index: number, count = 25) {
+      let url = `${ROBOTOFF_API_URL}/ann/search`;
+      if (logoId.length > 0) {
+        url += `/${logoId}`;
+      }
+
+      return axios.get(url, {
+        params: removeEmptyKeys({
+          index,
+          count,
+        }),
+      });
+    },
+
+    annotateLogos(annotations) {
+      return axios.post(
+        `${ROBOTOFF_API_URL}/images/logos/annotate`,
+        removeEmptyKeys({ annotations }),
+        { withCredentials: true },
+      );
+    },
+
+    getInsights(
+      barcode = "",
+      insightType = "",
+      valueTag = "",
+      annotation = "",
+      page = 1,
+      count = 25,
+      campaigns = "",
+      country = "",
+    ) {
+      let annotated;
+      if (annotation.length && annotation === "not_annotated") {
+        annotated = "0";
+        annotation = "";
+      }
+      return axios.get(`${ROBOTOFF_API_URL}/insights`, {
+        params: removeEmptyKeys({
+          barcode,
+          insight_types: insightType,
+          value_tag: valueTag,
+          annotation,
+          page,
+          annotated,
+          count,
+          campaigns,
+          countries: country,
+        }),
+      });
+    },
+
+    getUserStatistics(username: string) {
+      return axios.get(`${ROBOTOFF_API_URL}/users/statistics/${username}`);
+    },
+
+    getCroppedImageUrl(
+      imageUrl: string,
+      boundingBox: [number, number, number, number],
+    ) {
+      const [y_min, x_min, y_max, x_max] = boundingBox;
+
+      const params = new URLSearchParams({
+        image_url: imageUrl,
+        y_min: y_min.toString(),
+        x_min: x_min.toString(),
+        y_max: y_max.toString(),
+        x_max: x_max.toString(),
+      });
+
+      return `${ROBOTOFF_API_URL}/images/crop?${params.toString()}`;
+    },
+
+    getLogosImages(logoIds: string[]) {
+      const params = new URLSearchParams();
+      logoIds.forEach((id) => params.append("logo_ids", id));
+
+      return axios.get(`${ROBOTOFF_API_URL}/images/logos?${params.toString()}`);
+    },
+
+    getUnansweredValues({
+      page = 1,
+      countryCode,
+      ...other
+    }: {
+      type: "label" | "brand" | "category";
+      countryCode: string;
+      campaign: string;
+      page?: number;
+      count?: number;
+    }) {
+      return axios.get(
+        `${ROBOTOFF_API_URL}/questions/unanswered/?${Object.entries(
+          removeEmptyKeys({
+            ...other,
+            countries: countryCode,
+            page: page >= 1 ? page : 1,
+          }),
+        )
+          .map(([key, value]) => `${key}=${value}`)
+          .join("&")}`,
+      );
+    },
+  };
+
+  export default robotoff;

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -76,9 +76,7 @@
       count = 10,
       page = 1,
     ) {
-      // EDGE CASE FIX: Ensuring count and page are positive integers
-      const safeCount = Math.max(1, Math.floor(count));
-      const safePage = Math.max(1, Math.floor(page));
+
 
       const searchParams = {
         insight_types: insightType,
@@ -98,8 +96,8 @@
         params: removeEmptyKeys({
           ...searchParams,
           lang,
-          count: safeCount,
-          page: safePage,
+          count,
+          page,
         }),
       });
     },


### PR DESCRIPTION
### Description
This PR addresses the feedback regarding parameter clamping and PR reviewability. 

### Changes:
* **Refactored `annotate`**: Now uses the object-based `URLSearchParams` constructor for better readability and modern standards.
* **Cleaned `questions` logic**: Removed client-side parameter clamping (`Math.max` and `Math.floor`) as requested. Validation responsibility is now shifted to the consumer layer.
* **Resolved Whitespace Issues**: Performed a surgical reset and applied the project's Prettier configuration to eliminate non-breaking spaces and ensure a clean diff (+9/-7).

### Verification
- Verified the diff is small and surgical.
- Ran `yarn run prettier` to ensure compliance with project styling.