### PR TITLE
style: fix dark mode colors for tour popup

### DIFF
--- a/src/components/welcome/Welcome.jsx
+++ b/src/components/welcome/Welcome.jsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import GlobalStyles from "@mui/material/GlobalStyles";
 import { useTheme } from "@mui/material/styles";
 import useControlled from "@mui/utils/useControlled";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -337,8 +338,38 @@ const Welcome = (props) => {
     [t, isDesktop, theme],
   );
 
+  const isDark = theme.palette.mode === "dark";
+
   return (
     <>
+      {isDark && (
+        <GlobalStyles
+          styles={{
+            "#___reactour .reactour__close": {
+              color: theme.palette.text.secondary,
+              "&:hover": {
+                color: theme.palette.text.primary,
+              },
+            },
+            "#___reactour [data-tour-elem='left-arrow']": {
+              color: theme.palette.text.secondary,
+              "&:hover": {
+                color: theme.palette.text.primary,
+              },
+            },
+            "#___reactour [data-tour-elem='right-arrow']": {
+              color: theme.palette.text.secondary,
+              "&:hover": {
+                color: theme.palette.text.primary,
+              },
+            },
+            "#___reactour [data-tour-elem='dot']": {
+              color: theme.palette.text.secondary,
+              borderColor: theme.palette.text.secondary,
+            },
+          }}
+        />
+      )}
       <Tour
         steps={steps}
         startAt={0}


### PR DESCRIPTION
### What
Fixed tour navigation dots, arrows and close button being nearly invisible in dark mode by changing their color from text.disabled to text.secondary, matching the brightness of the arrow and close buttons.

### Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/94503898-0b8f-475b-89d2-8b1cb0235a85" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8465bdb1-8c66-4b8b-bd64-5004cb57809d" />


### Fixes bug(s)
https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/437

### Part of 
https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/437 
