### PR TITLE
chore: Use import.meta.env.DEV for dev mode

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -8,7 +8,7 @@ export const OFF_IMAGE_URL = `https://images.${OFF_DOMAIN}/images/products`;
 export const OFF_SEARCH = `${OFF_URL}/cgi/search.pl`;
 export const OFF_SEARCH_A_LISIOUS =
   "https://search.openfoodfacts.org/autocomplete";
-export const IS_DEVELOPMENT_MODE = process.env.NODE_ENV === "development";
+export const IS_DEVELOPMENT_MODE = import.meta.env.DEV;
 export const URL_ORIGINE = IS_DEVELOPMENT_MODE
   ? "http://localhost:5173"
   : "https://hunger.openfoodfacts.org";


### PR DESCRIPTION
### What
- Replaces process.env with import.meta, which is more idiomatic in Vite.
