### PR TITLE
fix: Lazy-load i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "husky": "^9.1.7",
+    "i18next-resources-to-backend": "^1.2.1",
     "knip": "^6.1.0",
     "prettier": "^3.6.2",
     "typescript": "^6.0.2",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,12 +1,14 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import { getLang } from "./localeStorageManager";
-import resources from "./i18n/messages";
+import resourcesToBackend from "i18next-resources-to-backend";
 
-i18n
+void i18n
   .use(initReactI18next) // passes i18n down to react-i18next
+  .use(
+    resourcesToBackend((language: string) => import(`./i18n/${language}.json`)),
+  )
   .init({
-    resources,
     fallbackLng: "en",
     lng: getLang(),
     interpolation: {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,4 +28,4 @@ root.render(
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+void reportWebVitals();

--- a/src/localeStorageManager.ts
+++ b/src/localeStorageManager.ts
@@ -100,17 +100,26 @@ export const getTour = () => {
 };
 
 export const getLang = () => {
-  const settings = localSettings.fetch();
-
+  // 1. Check URL params
   const urlParams = new URLSearchParams(window.location.search);
   const urlLanguage = urlParams.has("language") && urlParams.get("language");
+  if (urlLanguage) {
+    return urlLanguage;
+  }
 
-  return (
-    urlLanguage ||
-    settings[localSettingsKeys.language] ||
-    // @ts-expect-error Property 'userLanguage' does not exist on type 'Navigator'.
-    (navigator.language || navigator.userLanguage).split("-")[0]
-  );
+  // 2. Check local storage
+  const settings = localSettings.fetch<string | undefined>();
+  const settingsLanguage = settings[localSettingsKeys.language];
+  if (settingsLanguage) {
+    return settingsLanguage;
+  }
+
+  // 3. Use browser language
+  if (navigator && navigator.language) {
+    return navigator.language.split("-")[0];
+  }
+
+  return undefined;
 };
 
 export const getStoredColorPreference = (): "light" | "dark" | undefined => {

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -52,7 +52,7 @@ export default function Settings() {
     HTMLInputElement | HTMLTextAreaElement
   > = (e) => {
     localSettings.update(localSettingsKeys.language, e.target.value);
-    i18n.changeLanguage(e.target.value);
+    void i18n.changeLanguage(e.target.value);
     setLanguage(e.target.value);
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4500,6 +4500,7 @@ __metadata:
     globals: "npm:^16.5.0"
     husky: "npm:^9.1.7"
     i18next: "npm:^23.6.0"
+    i18next-resources-to-backend: "npm:^1.2.1"
     knip: "npm:^6.1.0"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.6.2"
@@ -4525,6 +4526,15 @@ __metadata:
   bin:
     husky: bin.js
   checksum: 10/c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
+  languageName: node
+  linkType: hard
+
+"i18next-resources-to-backend@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "i18next-resources-to-backend@npm:1.2.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+  checksum: 10/93e3d5ede02f4f9b1515759fe7c4f0b911aec1deceb1836e4b25926ff5c54d27d24e5e42c62a55ad1d911d9f9a0965d48b03fdf0028183215b5cd4f5d9465e5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dynamically load translation JSONs via i18next-resources-to-backend.

Prefix async calls with void to avoid unhandled promise warnings.
