### PR TITLE
fix(questions): hide filter chip when URL value is unresolvable

### DIFF
--- a/src/components/QuestionFilter/const.ts
+++ b/src/components/QuestionFilter/const.ts
@@ -18,6 +18,21 @@ export const DEFAULT_FILTER_STATE: FilterState = {
 
 export const campagnes = ["agribalyse-category"];
 
+// Drives both the FilterDialog dropdown and the chip-display check in
+// QuestionFilter. `labelKey` resolves under the i18n namespace
+// `questions.filters.predictor.<labelKey>`.
+export const predictors = [
+  { value: "ridge_model-ml", labelKey: "ridge_model_ml" },
+  { value: "neural", labelKey: "neural" },
+  { value: "matcher", labelKey: "matcher" },
+  { value: "google-could-vision", labelKey: "google_cloud_vision" },
+  { value: "regex", labelKey: "regex" },
+  { value: "flashtext", labelKey: "flashtext" },
+  { value: "nutriscore", labelKey: "nutriscore" },
+  { value: "universal-logo-detector", labelKey: "universal_logo_detector" },
+  { value: "ocr", labelKey: "ocr" },
+];
+
 export const countryNames = [
   "",
   "en:australia",

--- a/src/pages/questions/FilterDialog.tsx
+++ b/src/pages/questions/FilterDialog.tsx
@@ -23,6 +23,7 @@ import countries from "../../assets/countries.json";
 import {
   insightTypesNames,
   campagnes,
+  predictors,
 } from "../../components/QuestionFilter/const";
 import { useFilterState } from "../../hooks/useFilterState";
 import { BrandFilter } from "../../components/QuestionFilter/BrandFilter";
@@ -219,33 +220,11 @@ export default function FilterDialog(props: FilterDialogProps) {
             <MenuItem value="">
               <em>{t("questions.filters.all_predictors")}</em>
             </MenuItem>
-            <MenuItem value="ridge_model-ml">
-              {t("questions.filters.predictor.ridge_model_ml")}
-            </MenuItem>
-            <MenuItem value="neural">
-              {t("questions.filters.predictor.neural")}
-            </MenuItem>
-            <MenuItem value="matcher">
-              {t("questions.filters.predictor.matcher")}
-            </MenuItem>
-            <MenuItem value="google-could-vision">
-              {t("questions.filters.predictor.google_cloud_vision")}
-            </MenuItem>
-            <MenuItem value="regex">
-              {t("questions.filters.predictor.regex")}
-            </MenuItem>
-            <MenuItem value="flashtext">
-              {t("questions.filters.predictor.flashtext")}
-            </MenuItem>
-            <MenuItem value="nutriscore">
-              {t("questions.filters.predictor.nutriscore")}
-            </MenuItem>
-            <MenuItem value="universal-logo-detector">
-              {t("questions.filters.predictor.universal_logo_detector")}
-            </MenuItem>
-            <MenuItem value="ocr">
-              {t("questions.filters.predictor.ocr")}
-            </MenuItem>
+            {predictors.map(({ value, labelKey }) => (
+              <MenuItem key={value} value={value}>
+                {t(`questions.filters.predictor.${labelKey}`)}
+              </MenuItem>
+            ))}
           </TextField>
 
           <FormControlLabel

--- a/src/pages/questions/QuestionFilter.tsx
+++ b/src/pages/questions/QuestionFilter.tsx
@@ -20,7 +20,12 @@ import { TFunction } from "i18next/typescript/t";
 import { SetURLSearchParams, useSearchParams } from "react-router";
 
 import { useFavorite } from "../../components/QuestionFilter/useFavorite";
-import { insightTypesNames } from "../../components/QuestionFilter/const";
+import {
+  insightTypesNames,
+  campagnes,
+  predictors,
+} from "../../components/QuestionFilter/const";
+import countries from "../../assets/countries.json";
 import FilterDialog from "./FilterDialog";
 import { getFilterParams } from "../../hooks/useFilterState/getFilterParams";
 import { FilterState } from "../../robotoff";
@@ -48,7 +53,11 @@ const getChipsParams = (
 
     {
       key: "countryFilter",
-      display: !!filterState.country,
+      // Show the chip only when the URL value matches a dropdown country
+      // (its ISO `countryCode`)
+      display:
+        !!filterState.country &&
+        countries.some((c) => c.countryCode === filterState.country),
       label: `${t("questions.filters.short_label.country")}: ${getCountryName(
         filterState.country,
       )}`,
@@ -86,7 +95,8 @@ const getChipsParams = (
     },
     {
       key: "campaign",
-      display: !!filterState.campaign,
+      display:
+        !!filterState.campaign && campagnes.includes(filterState.campaign),
       label: `${t(
         "questions.filters.short_label.campaign",
       )}: ${filterState.campaign}`,
@@ -99,7 +109,7 @@ const getChipsParams = (
     },
     {
       key: "predictor",
-      display: !!filterState.predictor,
+      display: predictors.some((p) => p.value === filterState.predictor),
       label: `${t(
         "questions.filters.short_label.predictor",
       )}: ${filterState.predictor}`,


### PR DESCRIPTION
### What
Filter chips for country, campaign, and predictor used to render "<key>: undefined" when the URL value didn't resolve via lookup, e.g. external permalinks like `?country=en:world` or string-concatenated JS `undefined` from another OFF page.

Gate each chip's display on whether the URL value matches an option the corresponding dropdown would produce (new `isKnownFilterValue` helper). The URL itself is preserved verbatim, only the chip rendering changes, so back/forward navigation and external permalinks keep working unchanged.

Also dedupes the predictor dropdown options into a shared array in `const.ts` so FilterDialog and the new validator share one source of truth.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
| Before | After |
|:-----------------:|:----------------:|
|Fixed issue<img width="1386" height="1242" alt="image" src="https://github.com/user-attachments/assets/6e5104dc-e027-488c-868e-13df79bc1fc2" />|<img width="1250" height="633" alt="Screenshot 2026-05-24 185159" src="https://github.com/user-attachments/assets/b53e14b9-cb78-426f-b59a-605588ce4b81" /> |
|Sanity pass <img width="599" height="725" alt="image" src="https://github.com/user-attachments/assets/88abbce2-c42a-40f2-8880-a7185abff0a7" />|<img width="844" height="719" alt="image" src="https://github.com/user-attachments/assets/84b79632-bf15-4210-a8b7-73e40a09d017" />|





### Fixes bug(s)
Fixes #1360
