### PR TITLE
fix: load home page user statistics from /facets with credentials

### DIFF
--- a/src/pages/home/UserData.tsx
+++ b/src/pages/home/UserData.tsx
@@ -13,19 +13,25 @@ import { OFF_URL } from "../../const";
 
 const fetchUserData = async (userName: string) => {
   const editorPromise = axios
-    .get(`${OFF_URL}/editor/${userName}.json?fields=count`)
+    .get(`${OFF_URL}/facets/editor/${userName}.json?fields=count`, {
+      withCredentials: true,
+    })
     .then(({ data }) => {
       return data?.count;
     })
     .catch(() => undefined);
   const contributorPromise = axios
-    .get(`${OFF_URL}/contributor/${userName}.json?fields=count`)
+    .get(`${OFF_URL}/facets/contributor/${userName}.json?fields=count`, {
+      withCredentials: true,
+    })
     .then(({ data }) => {
       return data?.count;
     })
     .catch(() => undefined);
   const photographerPromise = axios
-    .get(`${OFF_URL}/photographer/${userName}.json?fields=count`)
+    .get(`${OFF_URL}/facets/photographer/${userName}.json?fields=count`, {
+      withCredentials: true,
+    })
     .then(({ data }) => {
       return data?.count;
     })


### PR DESCRIPTION
Problem

The Editor, Contributor, and Photographer statistics on the home page were showing N/A instead of the actual counts.

Cause

The requests that fetch these counts were failing for two reasons:

1. Wrong URL — Facet pages on Open Food Facts are now served under a /facets prefix. The old paths (/editor/..., /contributor/..., /photographer/...) no longer return data.
2. Blocked by rate limit — A new IP-independent rate limit blocks facet requests from non-logged-in users, so the calls were being rejected.

Fix

- Added the /facets prefix to all three requests.
- Added withCredentials: true so each request sends the user's Open Food Facts login cookie and passes the rate limit.

Notes

@alexfauquette also reported a CORS error when sending credentials. That needs the Open Food Facts server to allow credentialed requests from the Hunger Games origin, which is a server-side change outside this PR.

Closes #1526 