### PR TITLE
fix: update theme-color meta tag on theme change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -208,6 +208,14 @@ export default function App() {
   }, []);
 
   const theme = createTheme(getToken(mode));
+  const themeColor = theme.palette.cafeCreme.main;
+  React.useEffect(() => {
+    const metaThemeColor = document.head.querySelector(
+      'meta[name="theme-color"]',
+    );
+    if (!metaThemeColor) return;
+    metaThemeColor.setAttribute("content", themeColor);
+  }, [themeColor]);
 
   return (
     <React.Suspense fallback={<Loader />}>


### PR DESCRIPTION
Fix #1585

## Summary

- Updates the `theme-color` meta tag when switching between light and dark themes.

- Keeps the browser UI color synchronized with the current application theme.

## Testing

- Verified that the `theme-color` meta tag updates correctly when toggling between light and dark mode.
- In Dark Mode
<img width="1470" height="459" alt="Screenshot 2026-08-05 at 5 25 35 PM" src="https://github.com/user-attachments/assets/0557b24c-abfa-4e07-857f-c1f306a3fe2f" />
-In Light Mode
<img width="1470" height="523" alt="Screenshot 2026-08-05 at 5 26 20 PM" src="https://github.com/user-attachments/assets/77f7daed-c172-40d9-9b98-ed67e3e4e69e" />
