### PR TITLE
fix: restore image reporting button on the question page

### DIFF
--- a/src/pages/questions/ProductInformation.tsx
+++ b/src/pages/questions/ProductInformation.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 
 import { useTranslation } from "react-i18next";
-import { useTheme } from "@mui/material/styles";
+import { useTheme, alpha } from "@mui/material/styles";
 
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import OutlinedFlagIcon from "@mui/icons-material/OutlinedFlag";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
@@ -23,6 +26,7 @@ import ZoomableImage from "../../components/ZoomableImage";
 
 import { NO_QUESTION_LEFT } from "../../const";
 import offService from "../../off";
+import externalApi from "../../externalApi";
 import {
   localSettings,
   localSettingsKeys,
@@ -31,7 +35,11 @@ import {
   getIsDevMode,
 } from "../../localeStorageManager";
 
-import { ADDITIONAL_INFO_TRANSLATION, getImagesUrls } from "./utils";
+import {
+  ADDITIONAL_INFO_TRANSLATION,
+  getImageId,
+  getImagesUrls,
+} from "./utils";
 import useQuestions from "../../hooks/useQuestions";
 import { useProductData } from "../../hooks/useProduct";
 import { Skeleton } from "@mui/material";
@@ -43,6 +51,7 @@ const ProductImagesGrid = ({
   images: Record<string, { uploaded_t: number }>;
   barcode: string;
 }) => {
+  const { t } = useTranslation();
   const theme = useTheme();
   const imageUrls = getImagesUrls(images, barcode).reverse();
 
@@ -71,6 +80,7 @@ const ProductImagesGrid = ({
         <Box key={src.imageUrl}>
           <Box
             sx={{
+              position: "relative",
               width: "100%",
               aspectRatio: "1 / 1",
               overflow: "hidden",
@@ -93,30 +103,25 @@ const ProductImagesGrid = ({
                 },
               }}
             />
-            {/* {flagged.includes(getImageId(src.imageUrl)) ? (
-            <Tooltip title={t("questions.unflag")}>
-              <IconButton
-                onClick={() =>
-                  deleteFlagImage(src.imageUrl, question.barcode)
-                }
-              >
-                <FlagIcon />
-              </IconButton>
-            </Tooltip>
-          ) : (
             <Tooltip title={t("questions.flag")}>
               <IconButton
                 onClick={() =>
                   externalApi.addImageFlag({
-                    barcode: question.barcode,
+                    barcode,
                     imgid: getImageId(src.imageUrl),
                   })
                 }
+                sx={{
+                  position: "absolute",
+                  color: "white",
+                  backgroundColor: alpha(theme.palette.secondary.main, 0.5),
+                  bottom: 5,
+                  right: 5,
+                }}
               >
                 <OutlinedFlagIcon />
               </IconButton>
             </Tooltip>
-          )} */}
           </Box>
           <Typography variant="caption">{src.uploaded_t}</Typography>
         </Box>


### PR DESCRIPTION
Fixes #1550

## The problem

On the questions page, every product image used to have a small flag button.
You could click it to report a bad image — for example a photo of the wrong
product, a blurry photo, or a photo with someone's face in it.

That button is gone. Right now users have no way to report a bad image.

## Why it went missing

The button was never actually deleted. It was still sitting in the code, but
it was wrapped inside a comment, so the browser simply ignored it.

Here is how that happened, step by step:

1. The button used two variables called `flagged` and `deleteFlagImage`.
   These were removed from the file at some point, so the button was
   pointing at things that no longer existed.
2. In #1434, someone hit this broken code. Instead of fixing it, they
   commented the whole button out to make the error go away. **This is the
   commit where the feature was actually lost.**
3. #1381 later moved image reporting over to Nutri-Patrol. But it only
   edited a line that was already inside that comment, so nothing changed
   for users.
4. The file was later rewritten from JSX to TypeScript, and the comment was
   copied across as-is.

So the button has been invisible to users since step 2.

## The fix

I brought the button back and connected it to Nutri-Patrol.

Only one file changed: `src/pages/questions/ProductInformation.tsx`

- Removed the old commented-out code
- Added a working report button on each image in the grid
- The button calls `externalApi.addImageFlag()`, which opens Nutri-Patrol in
  a new tab with the product barcode and the image id
- Placed it in the bottom-right corner, because `ZoomableImage` already puts
  its expand button in the bottom-left
- Reused the existing `questions.flag` translation key, so the tooltip
  already works in every language. No new translation strings needed.

## One decision worth explaining

The old code had two buttons that swapped: "flag" and "unflag". I only
brought back "flag".

Reporting now happens on Nutri-Patrol, which is a separate website — our app
just opens it in a new tab. We no longer keep a local list of reported
images, and `externalApi` has no `deleteImageFlag` function anymore. An
unflag button would look like it works but do nothing, so I left it out.

## How I tested it

- [x] The flag button appears on every image in the grid
- [x] Hovering shows the tooltip text
- [x] Clicking opens Nutri-Patrol in a new tab with the correct `barcode`
      and `image_id`
- [x] Works in both light mode and dark mode
- [x] The "Hide images" checkbox still works
- [x] Products with no images still load without errors
- [x] `npm run build` passes
- [x] `eslint` on this file reports the same 3 pre-existing errors as on
      master — no new ones

