### PR TITLE
feat: show all Green-Score categories with search and sorting

### DIFF
--- a/src/components/Opportunities.tsx
+++ b/src/components/Opportunities.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Link } from "react-router";
+import { useTranslation } from "react-i18next";
 
 import Typography from "@mui/material/Typography";
 import Card from "@mui/material/Card";
@@ -7,7 +8,9 @@ import CardActionArea from "@mui/material/CardActionArea";
 import CardContent from "@mui/material/CardContent";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
-import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
 
 import Loader from "../pages/loader";
 
@@ -16,9 +19,38 @@ import off from "../off";
 import { getQuestionSearchParams } from "./QuestionFilter/useFilterSearch";
 import { getLang } from "../localeStorageManager";
 
-const pageSize = 25;
+// A single request returns every category (~937 worldwide, ~25 KB). Robotoff
+// takes about the same time whatever `count` is, so paging only added waiting.
+const MAX_CATEGORIES = 1000;
 
-const OpportunityCard = (props) => {
+// The taxonomy endpoint passes every tag in the query string, and the server
+// answers 414 past ~8 KB of URL. Batch the lookups to stay well under that.
+const TRANSLATION_BATCH_SIZE = 100;
+
+type InsightType = "label" | "brand" | "category";
+
+/** Robotoff returns each row as a [tag, questionNumber] pair. */
+type CategoryCount = [string, number];
+
+/** Taxonomy lookup: tag -> localised names, keyed by language code. */
+type CategoryNames = Record<string, { name?: Record<string, string> }>;
+
+type SortBy = "count" | "name";
+
+type OpportunitiesProps = {
+  type: InsightType;
+  campaign: string;
+  countryCode: string;
+};
+
+const OpportunityCard = (props: {
+  type: InsightType;
+  value: string;
+  name: string;
+  campaign: string;
+  countryCode: string;
+  questionNumber: number;
+}) => {
   const { type, value, name, campaign, countryCode, questionNumber } = props;
 
   const targetUrl = `/questions?${getQuestionSearchParams({
@@ -70,37 +102,60 @@ const CardSkeleton = () => (
   </React.Suspense>
 );
 
-const useTranslation = (toTranslate) => {
-  const [translation, setTranslation] = React.useState({});
+const useCategoryNames = (toTranslate: string[]) => {
+  const [translation, setTranslation] = React.useState<CategoryNames>({});
+  const requested = React.useRef(new Set<string>());
+
+  // Join into a stable string so the effect only reruns when the set of tags
+  // actually changes, rather than on every render.
+  const tagKey = toTranslate.join(",");
 
   React.useEffect(() => {
-    const remaining = toTranslate.filter((key) => !translation[key]);
+    let isValid = true;
 
-    if (remaining.length > 0) {
+    const missing = (tagKey ? tagKey.split(",") : []).filter(
+      (tag) => !requested.current.has(tag),
+    );
+
+    if (missing.length === 0) {
+      return;
+    }
+    missing.forEach((tag) => requested.current.add(tag));
+
+    for (let i = 0; i < missing.length; i += TRANSLATION_BATCH_SIZE) {
       off
-        .getCategoriesTranslations({ categories: remaining })
-        .then(({ data }) => {
-          setTranslation((prev) => ({
-            ...prev,
-            ...data,
-          }));
+        .getCategoriesTranslations({
+          categories: missing.slice(i, i + TRANSLATION_BATCH_SIZE),
+        })
+        .then(({ data }: { data: CategoryNames }) => {
+          if (isValid) {
+            setTranslation((prev) => ({
+              ...prev,
+              ...data,
+            }));
+          }
         })
         .catch(() => {});
     }
-  }, [toTranslate]);
+
+    return () => {
+      isValid = false;
+    };
+  }, [tagKey]);
 
   return translation;
 };
 
-const Opportunities = (props) => {
+const Opportunities = (props: OpportunitiesProps) => {
   const { type, campaign, countryCode } = props;
-  const [remainingQuestions, setRemainingQuestions] = React.useState([]);
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [page, setPage] = React.useState(1);
+  const { t } = useTranslation();
 
-  React.useEffect(() => {
-    setRemainingQuestions([]);
-  }, [type, campaign, countryCode]);
+  const [remainingQuestions, setRemainingQuestions] = React.useState<
+    CategoryCount[]
+  >([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [search, setSearch] = React.useState("");
+  const [sortBy, setSortBy] = React.useState<SortBy>("count");
 
   React.useEffect(() => {
     let isValid = true;
@@ -111,38 +166,89 @@ const Opportunities = (props) => {
         type,
         campaign,
         countryCode,
-        page,
-        count: pageSize,
+        page: 1,
+        count: MAX_CATEGORIES,
       })
-      .then(({ data }) => {
+      .then(({ data }: { data?: { questions?: CategoryCount[] } }) => {
         if (isValid) {
-          setRemainingQuestions((prev) => [
-            ...prev,
-            ...(data?.questions ?? []),
-          ]);
+          setRemainingQuestions(data?.questions ?? []);
           setIsLoading(false);
         }
       })
       .catch(() => {
-        setIsLoading(false);
+        if (isValid) {
+          setRemainingQuestions([]);
+          setIsLoading(false);
+        }
       });
 
     return () => {
       isValid = false;
     };
-  }, [type, campaign, countryCode, page]);
+  }, [type, campaign, countryCode]);
 
-  const translation = useTranslation(
+  const translation = useCategoryNames(
     remainingQuestions.map(([value]) => value),
   );
 
-  const lang = getLang();
+  const lang: string = getLang();
+
+  const visibleCategories = React.useMemo(() => {
+    const rows = remainingQuestions.map(([value, questionNumber]) => ({
+      value,
+      questionNumber,
+      name:
+        translation[value]?.name?.[lang] ??
+        translation[value]?.name?.en ??
+        value,
+    }));
+
+    const query = search.trim().toLowerCase();
+    const filtered = query
+      ? rows.filter(
+          (row) =>
+            row.name.toLowerCase().includes(query) ||
+            row.value.toLowerCase().includes(query),
+        )
+      : rows;
+
+    return sortBy === "name"
+      ? [...filtered].sort((a, b) => a.name.localeCompare(b.name))
+      : [...filtered].sort((a, b) => b.questionNumber - a.questionNumber);
+  }, [remainingQuestions, translation, lang, search, sortBy]);
+
   return (
     <React.Suspense fallback={<Loader />}>
       <Box sx={{ mt: 2, px: 2 }}>
         <Typography variant="h6" component="h3">
           {type}
         </Typography>
+
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          sx={{ my: 2 }}
+        >
+          <TextField
+            size="small"
+            label={t("green-score.searchCategory")}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            sx={{ flexGrow: 1, maxWidth: 400 }}
+          />
+          <TextField
+            select
+            size="small"
+            label={t("green-score.sortBy")}
+            value={sortBy}
+            onChange={(event) => setSortBy(event.target.value as SortBy)}
+            sx={{ width: 220 }}
+          >
+            <MenuItem value="count">{t("green-score.sortByCount")}</MenuItem>
+            <MenuItem value="name">{t("green-score.sortByName")}</MenuItem>
+          </TextField>
+        </Stack>
+
         <Box
           sx={{
             display: "grid",
@@ -150,37 +256,26 @@ const Opportunities = (props) => {
             gridGap: "10px 50px",
           }}
         >
-          {remainingQuestions.map(([value, questionNumber]) => {
-            const name =
-              translation[value]?.name?.[lang] ??
-              translation[value]?.name?.en ??
-              value;
-            return (
-              <OpportunityCard
-                key={value}
-                value={value}
-                name={name}
-                type={type}
-                campaign={campaign}
-                countryCode={countryCode}
-                questionNumber={questionNumber}
-              />
-            );
-          })}
+          {visibleCategories.map(({ value, questionNumber, name }) => (
+            <OpportunityCard
+              key={value}
+              value={value}
+              name={name}
+              type={type}
+              campaign={campaign}
+              countryCode={countryCode}
+              questionNumber={questionNumber}
+            />
+          ))}
           {isLoading &&
-            [
-              0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-              19, 20, 21, 22, 23, 24,
-            ].map((id) => <CardSkeleton key={id} />)}
-          <Button
-            disabled={isLoading}
-            variant="contained"
-            fullWidth
-            onClick={() => setPage((p) => p + 1)}
-          >
-            Load more
-          </Button>
+            Array.from({ length: 12 }, (_, id) => <CardSkeleton key={id} />)}
         </Box>
+
+        {!isLoading && visibleCategories.length === 0 && (
+          <Typography sx={{ mt: 2 }}>
+            {t("green-score.noCategories")}
+          </Typography>
+        )}
       </Box>
     </React.Suspense>
   );

--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -392,7 +392,12 @@
   },
   "green-score": {
     "description": "Here is a summary of questions that could improve Green-Score computation",
-    "countryLabel": "Country"
+    "countryLabel": "Country",
+    "searchCategory": "Search a category",
+    "sortBy": "Sort by",
+    "sortByCount": "Number of questions",
+    "sortByName": "Name (A-Z)",
+    "noCategories": "No category matches your search"
   },
   "ingredients": {
     "description": "This game allows you to validate the pre-selection of images of ingredients lists in various languages for a product, and validate the extracted ingredients.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -393,7 +393,12 @@
   },
   "green-score": {
     "description": "Here is a summary of questions that could improve Green-Score computation",
-    "countryLabel": "Country"
+    "countryLabel": "Country",
+    "searchCategory": "Search a category",
+    "sortBy": "Sort by",
+    "sortByCount": "Number of questions",
+    "sortByName": "Name (A-Z)",
+    "noCategories": "No category matches your search"
   },
   "ingredients": {
     "description": "This game allows you to validate the pre-selection of images of ingredients lists in various languages for a product, and validate the extracted ingredients.",


### PR DESCRIPTION
Refs #1558

Addresses points 2-5 of the issue. The daily cache and GitHub Action (point 1)
are deliberately left out — see the note at the bottom.

## The problem

The category list loads 25 at a time behind a "Load more" button. I measured
the Robotoff endpoint:

| request | rows | payload | time |
|---|---|---|---|
| `count=25` (current) | 25 | 629 B | 4.59 s |
| `count=1000` | 937 | 25 KB | 4.94 s |

**The response time is the query, not the transfer.** Asking for everything
costs the same as asking for 25.

So seeing all 937 categories today means clicking "Load more" 38 times and
waiting ~5s each — about 3 minutes — to transfer 25 KB that arrives in one
request.

## Changes

All in `src/components/Opportunities.tsx`, plus 5 new `green-score.*` keys.

- **One request, no pagination.** Removed the `page` state and the "Load more"
  button. Also removed the now-redundant reset effect, since the list is
  replaced rather than appended to.
- **Search box.** Matches the translated name *and* the raw tag — category
  names arrive from a second async call, so tag-matching keeps search working
  in the meantime.
- **Sort selector.** Number of questions (default) or name A-Z.
- **Controls render immediately** rather than behind the loading state.

## Batching the taxonomy lookups

Removing pagination surfaced a problem worth calling out. `getCategoriesTranslations`
passes every tag in the query string:

| tags | URL length | result |
|---|---|---|
| 400 | 6,803 | 200 OK |
| 500 | 8,930 | **414 URI Too Long** |
| 937 | 18,933 | **connection dropped** |

Fine at 25 per page. With all 937 it fails outright, and every card falls back
to showing its raw tag (`en:chickens` instead of "Chickens"). Lookups are now
batched at 100 tags per request, with a ref-tracked set so no tag is requested
twice.

## Incidental fixes

- **Typed the component.** Error count was climbing against an already-messy
  file, so I added proper types. `eslint src/components/Opportunities.tsx` now
  reports **0 errors, down from 29** on master.
- **Race condition:** the fetch `.catch` didn't check `isValid`, so a quickly
  abandoned request could clear the loading state of the one that replaced it.
- Replaced the hand-written `[0, 1, 2, ... 24]` skeleton array with
  `Array.from({ length: 12 })`.

## On the daily cache (point 1)

I left it out on purpose and would like your steer before building it:

- 252 countries × ~5 s per request ≈ **21 minutes** of hammering Robotoff daily
- A daily commit touching hundreds of files is significant repo churn
- Realistically only ~50-100 countries have meaningful data

Would you prefer caching `world` plus a top-N set of countries, with a live API
fallback for the rest? Happy to do it as a follow-up PR once the shape is agreed.

## Verification

Verified locally:

- `npm run build` passes
- `npx eslint src/components/Opportunities.tsx` — clean, 0 errors (29 on master)
- `prettier --check` clean on all three files
- New i18n keys confirmed present exactly once in `en.json` and `common.json`
- API measurements above taken directly against the live Robotoff and
  taxonomy endpoints

**Not yet verified in a browser** — I'd appreciate a reviewer confirming the
search/sort interaction and that category names resolve correctly with the
batched lookups.

