### PR TITLE
fix(green-score): use vector bio image on the organic card

### DIFF
--- a/src/pages/green-score/cards.tsx
+++ b/src/pages/green-score/cards.tsx
@@ -15,7 +15,7 @@ const greenScoreCards: CardProps[] = [
       valueTag: "en:organic",
     },
     title: "en:organic",
-    imageSrc: `https://images.${OFF_DOMAIN}/images/lang/fr/labels/bio.96x90.png`,
+    imageSrc: `https://images.${OFF_DOMAIN}/images/lang/fr/labels/bio.96x90.svg`,
   },
   {
     filterState: {


### PR DESCRIPTION
The Bio logo on the Green-Score page is a PNG, while all 12 other logos on
that page are SVGs. The card stretches every logo to 150px tall, and because
the PNG is only 96x90, it gets blown up and looks blurry next to the sharp
ones. This changes it to the SVG version.

⚠️ Please don't merge yet. The SVG file doesn't exist on the image server
yet — it's being added by openfoodfacts/openfoodfacts-server#14230, which is
still open. Right now the URL returns a 404, so merging this early would put
a broken image on the live page.

I'll comment here as soon as the file is live and this is safe to merge.

Fixes #1587
