### PR TITLE
feat(questions): make missing product fields actionable

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -91,6 +91,7 @@
     "no_similar_questions": "No similar questions",
     "no_images": "No images available",
     "no_additional_info": "No additional information",
+    "add_missing_info": "Add",
     "filters": {
       "active_filter_number": "+{{count}} filters",
       "active_filter_number_one": "+{{count}} filter",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -92,6 +92,7 @@
     "no_similar_questions": "No similar questions",
     "no_images": "No images available",
     "no_additional_info": "No additional information",
+    "add_missing_info": "Add",
     "filters": {
       "active_filter_number": "+{{count}} filters",
       "active_filter_number_one": "+{{count}} filter",

--- a/src/pages/questions/ProductInformation.tsx
+++ b/src/pages/questions/ProductInformation.tsx
@@ -14,6 +14,7 @@ import Checkbox from "@mui/material/Checkbox";
 import Typography from "@mui/material/Typography";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import EditIcon from "@mui/icons-material/Edit";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -132,8 +133,10 @@ const ProductImagesGrid = ({
 
 const ProductInfoTable = ({
   product,
+  barcode,
 }: {
   product: Record<string, unknown>;
+  barcode: string;
 }) => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -141,17 +144,46 @@ const ProductInfoTable = ({
   function ProductInfoRow({
     product,
     infoKey,
+    barcode,
   }: {
     product: Record<string, unknown>;
     infoKey: string;
+    barcode: string;
   }) {
-    const { i18nKey, translatedKey, getLink } =
+    const { i18nKey, translatedKey, getLink, editAnchor } =
       ADDITIONAL_INFO_TRANSLATION[infoKey];
 
-    // Try translated key first, then fallback to original key, then "?" if not found
-    const value =
-      (translatedKey ? product?.[translatedKey] : product?.[infoKey]) ??
-      ("?" as unknown);
+    const value = translatedKey ? product?.[translatedKey] : product?.[infoKey];
+
+    const isMissing =
+      value == null ||
+      (typeof value === "string" && value.trim() === "") ||
+      (Array.isArray(value) && value.length === 0);
+
+    if (isMissing) {
+      return (
+        <TableRow>
+          <TableCell component="th" scope="row">
+            {t(`questions.${i18nKey}`)}
+          </TableCell>
+          <TableCell>
+            <Button
+              size="small"
+              component={Link}
+              target="_blank"
+              rel="noreferrer"
+              href={`${offService.getProductEditUrl(barcode)}${
+                editAnchor ? `#${editAnchor}` : ""
+              }`}
+              startIcon={<AddCircleOutlineIcon />}
+              sx={{ py: 0, minWidth: 0 }}
+            >
+              {t("questions.add_missing_info")}
+            </Button>
+          </TableCell>
+        </TableRow>
+      );
+    }
 
     return (
       <TableRow>
@@ -199,7 +231,12 @@ const ProductInfoTable = ({
       >
         {Object.keys(ADDITIONAL_INFO_TRANSLATION).map((infoKey) => {
           return (
-            <ProductInfoRow key={infoKey} product={product} infoKey={infoKey} />
+            <ProductInfoRow
+              key={infoKey}
+              product={product}
+              infoKey={infoKey}
+              barcode={barcode}
+            />
           );
         })}
       </TableBody>
@@ -333,7 +370,7 @@ const ProductInformation = () => {
           {t("questions.no_additional_info")}
         </Typography>
       ) : (
-        <ProductInfoTable product={productData} />
+        <ProductInfoTable product={productData} barcode={question.barcode} />
       )}
 
       {isDevMode && devCustomization.showDebug && (

--- a/src/pages/questions/utils.ts
+++ b/src/pages/questions/utils.ts
@@ -8,18 +8,21 @@ type AdditionalInfoType = {
   i18nKey: string;
   translatedKey?: string;
   getLink?: (name: string) => string;
+  editAnchor?: string;
 };
 
 export const ADDITIONAL_INFO_TRANSLATION: Record<string, AdditionalInfoType> = {
-  brands: { i18nKey: "brands" },
-  ingredientsText: { i18nKey: "ingredients" },
+  brands: { i18nKey: "brands", editAnchor: "brands" },
+  ingredientsText: { i18nKey: "ingredients", editAnchor: "ingredients" },
   countriesTags: {
     i18nKey: "countries",
     translatedKey: "translatedCountriesTags",
+    editAnchor: "countries",
   },
   categories: {
     i18nKey: "categories",
     translatedKey: "translatedCategories",
+    editAnchor: "categories",
     getLink: (name: string) =>
       `https://world.openfoodfacts.org/facets/categories/${name
         .toLowerCase()
@@ -28,12 +31,13 @@ export const ADDITIONAL_INFO_TRANSLATION: Record<string, AdditionalInfoType> = {
   labels_tags: {
     i18nKey: "labels",
     translatedKey: "translatedLabels_tags",
+    editAnchor: "labels",
     getLink: (name: string) =>
       `https://world.openfoodfacts.org/facets/labels/${name
         .toLowerCase()
         .replaceAll(" ", "-")}`,
   },
-  quantity: { i18nKey: "quantity" },
+  quantity: { i18nKey: "quantity", editAnchor: "quantity" },
 };
 
 // src looks like: "https://images.openfoodfacts.org/images/products/004/900/053/2258/1.jpg"


### PR DESCRIPTION
Right now, when a product is missing a field, the info panel in the Questions game just shows a plain `?`. It's a dead end — you're looking straight at a photo of the packaging, you can see the missing information, but there's no way to act on it without hunting for the Edit button and starting over.

This implements the first step you suggested: each missing row now shows an **Add** link that opens the product's edit page, deep-linked to the relevant field with an anchor.

### What changed

- `ADDITIONAL_INFO_TRANSLATION` gains an optional `editAnchor` per field
- Missing rows render an `Add` link instead of the dead `?`
- One new translation key, `questions.add_missing_info`, in `common.json`

### Also fixed

The old fallback was `value ?? "?"`, which only catches `null` and `undefined`. A field that came back as an **empty array** slipped past it, hit the `Array.isArray` branch, mapped over nothing and rendered a completely blank cell — not even a `?`. The new `isMissing` check treats empty strings and empty arrays as missing too.

### Worth confirming

I couldn't verify the `#brands` / `#categories` style anchors myself — `product.pl?type=edit` requires login, so logged out I only get the sign-in form. If the real field ids differ, the `editAnchor` values need adjusting. The code degrades safely either way: no anchor just opens the top of the edit page, still better than a dead `?`.

### Follow-up

I've deliberately left the second half of the issue — inline Robotoff prediction chips per field — for a separate PR. The plumbing already exists (`useProductQuestions` + the Yes/No/Send pattern in `ProductOtherQuestions`), and insights carry an `insight_type` that maps onto four of these six rows, so it's very doable as a focused follow-up.

### Question

For the missing rows, would you prefer this `Add` link, or keeping the `?` and making it clickable? The link is more discoverable but slightly noisier when a product is missing several fields at once. Happy to switch.

Part of #1545
