### PR TITLE
fix(dashboard): make logos legible in dark mode

### DIFF
--- a/src/pages/logosValidator/DashboardCard.tsx
+++ b/src/pages/logosValidator/DashboardCard.tsx
@@ -84,7 +84,13 @@ const DashboardCard = (props: LogoDefinition) => {
             height="150"
             image={logo}
             alt=""
-            sx={{ objectFit: "contain" }}
+            sx={(theme) => ({
+              objectFit: "contain",
+              ...(theme.palette.mode === "dark" && {
+                backgroundColor: theme.palette.common.white,
+                p: 1,
+              }),
+            })}
           />
           <CardContent sx={{ flexGrow: 1 }}>
             <Typography gutterBottom variant="h5" component="div">


### PR DESCRIPTION
### The problem

Most label logos are **black drawings on a see-through background**. In dark
mode they sat on a dark card, so they were black on black and you couldn't
see them.

I checked the two logos from your screenshots:

- `klbd-kosher.90x90.png` — transparent background, black artwork
- `kosher-baint.90x90.svg` — `fill="#000000"`, no background

### The fix

In dark mode, each logo now sits on a small white panel. Light mode is
unchanged.

### Why this way

The issue lists four options. This one was the only one that works everywhere
without extra data:

- **A whitelist** would mean checking all **419** logos by hand, and checking
  again every time a logo is added.
- **Light/dark versions on the server** is the better long-term fix, but
  that's a much bigger job in Product Opener.
- **Colour-flipping the images** would fix the black logos but ruin all the
  colourful ones.

A white panel works for every logo, needs no list to maintain, and matches how
these logos were designed to be seen. The app already does something similar —
`ProductImagesGrid` changes image backgrounds based on light/dark mode.

**Trade-off:** logos that already looked fine now get a white panel too. I
think it looks tidier when they all match, but happy to change it if you'd
prefer something more selective.

### Scope

Only the Logos Dashboard, as the issue asks. The Green-Score page shows logos
the same way and might have the same problem, but its logos are mostly
colourful. Happy to fix that separately if you want.

Fixes #479
