### PR TITLE
chore: complete day 1 lint cleanup

### DIFF
--- a/src/components/AnnotateLogoModal.tsx
+++ b/src/components/AnnotateLogoModal.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -6,7 +6,7 @@ export class ErrorBoundary extends React.Component {
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError(_error) {
     // Update state so the next render will show the fallback UI.
     return { hasError: true };
   }

--- a/src/components/OffWebcomponents.tsx
+++ b/src/components/OffWebcomponents.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { OFF_IMAGE_URL, OFF_URL, ROBOTOFF_API_URL } from "../const";
 import { useTranslation } from "react-i18next";
 import "@openfoodfacts/openfoodfacts-webcomponents";

--- a/src/components/QuestionFilter/BrandFilter.tsx
+++ b/src/components/QuestionFilter/BrandFilter.tsx
@@ -16,7 +16,7 @@ export function BrandFilter(props: BrandFilterProps) {
     <Autocomplete
       freeSolo
       value={value}
-      onChange={(event, newValue: string | null) => onChange(newValue ?? "")}
+      onChange={(_event, newValue: string | null) => onChange(newValue ?? "")}
       options={brands}
       renderInput={(params) => (
         <TextField

--- a/src/components/QuestionFilter/LabelFilter.tsx
+++ b/src/components/QuestionFilter/LabelFilter.tsx
@@ -6,7 +6,7 @@ import { SearchApi } from "@openfoodfacts/openfoodfacts-nodejs";
 
 import { useQuery } from "@tanstack/react-query";
 
-const offClient = new SearchApi(window.fetch);
+const offClient = new SearchApi(window.fetch.bind(window));
 
 type TaxonomyOption = {
   id: string;
@@ -80,7 +80,7 @@ const LabelFilter = (props: LabelFilterProps) => {
         setInnerValue(newValue);
         onChange(typeof newValue === "object" ? newValue?.id : newValue);
       }}
-      onInputChange={(e, newInputValue) => {
+      onInputChange={(_event, newInputValue) => {
         setInputValue(newInputValue);
       }}
       onBlur={() => {
@@ -108,7 +108,7 @@ const LabelFilter = (props: LabelFilterProps) => {
             ((typeof innerValue === "object" && innerValue?.id) ||
               (innerValue !== "" &&
                 innerValue !== null &&
-                `⚠️ unknown: "${innerValue}"`))
+                `⚠️ unknown: "${typeof innerValue === "string" ? innerValue : innerValue.text}"`))
           }
         />
       )}

--- a/src/components/QuestionFilter/useFilterSearch.js
+++ b/src/components/QuestionFilter/useFilterSearch.js
@@ -78,7 +78,7 @@ export function useFilterSearch() {
       if (isSaved) {
         localFavorites.removeQuestion(exposedParameters);
       } else {
-        localFavorites.addQuestion(exposedParameters, logo, title);
+        localFavorites.addQuestion(exposedParameters, imageSrc, title);
       }
 
       setIsFavorite(!isSaved);

--- a/src/components/ResponsiveAppBar.tsx
+++ b/src/components/ResponsiveAppBar.tsx
@@ -196,11 +196,7 @@ const ResponsiveAppBar = () => {
     url?: string;
   }) => {
     if (page.devModeOnly) {
-      return (
-        isDevMode &&
-        !!page.url &&
-        visiblePages[page.url as keyof typeof visiblePages]
-      );
+      return isDevMode && !!page.url && visiblePages[page.url];
     }
     if (page.mobileOnly) {
       return !isDesktop;
@@ -279,6 +275,7 @@ const ResponsiveAppBar = () => {
                   if (page.url) {
                     return (
                       <MenuItem
+                        key={page.translationKey}
                         color="inherit"
                         sx={{ display: "block" }}
                         {...(isExternalUrl(page.url)
@@ -474,7 +471,6 @@ const ResponsiveAppBar = () => {
                   return (
                     <MultiPagesButton
                       {...page}
-                      children={children}
                       key={page.translationKey}
                       isExternalUrl={isExternalUrl}
                       isOpen={!!menuOpenState[`Desktop-${page.translationKey}`]}
@@ -485,7 +481,9 @@ const ResponsiveAppBar = () => {
                             !prev[`Desktop-${page.translationKey}`],
                         }))
                       }
-                    />
+                    >
+                      {children}
+                    </MultiPagesButton>
                   );
                 }
 

--- a/src/components/TaxonomyAutoSelect.tsx
+++ b/src/components/TaxonomyAutoSelect.tsx
@@ -41,7 +41,7 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
           callback: (results?: readonly TaxonomyItem[]) => void,
         ) => {
           searchTaxonomy[taxonomy](request.input, language).then(({ data }) => {
-            callback((data?.options as TaxonomyItem[]) ?? []);
+            callback(data?.options ?? []);
           });
         },
         400,
@@ -94,7 +94,7 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
       }
       isOptionEqualToValue={isOptionEqualToValue}
       // noOptionsText="No locations"
-      onChange={(event: any, newValue: TaxonomyItem | null | string) => {
+      onChange={(_event: any, newValue: TaxonomyItem | null | string) => {
         if (typeof newValue === "object") {
           onChange(newValue.text, newValue);
           setSelectedValue(newValue);
@@ -102,7 +102,7 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
         }
         onChange(newValue);
       }}
-      onInputChange={(event, newInputValue) => {
+      onInputChange={(_event, newInputValue) => {
         setInputValue(newInputValue);
       }}
       onBlur={() => {

--- a/src/components/welcome/Welcome.jsx
+++ b/src/components/welcome/Welcome.jsx
@@ -306,7 +306,7 @@ const getSteps = ({ t, withSelector, theme }) => [
 ];
 
 const Welcome = (props) => {
-  const { isOpen, setIsOpen } = props;
+  const { setIsOpen } = props;
 
   const { t } = useTranslation();
   const theme = useTheme();

--- a/src/externalApi.ts
+++ b/src/externalApi.ts
@@ -14,7 +14,7 @@ export const addImageFlag = (opts: { barcode: string; imgid: number }) => {
   try {
     window.open(NutriPatrolURL, "_blank", "noopener,noreferrer");
   } catch (error) {
-    throw new Error("Could not open NutriPatrol, error: " + error);
+    throw new Error("Could not open NutriPatrol", { cause: error });
   }
 };
 

--- a/src/l10n-shortcuts.ts
+++ b/src/l10n-shortcuts.ts
@@ -6,11 +6,6 @@ type Shortcuts = {
   skip: string;
 };
 
-type ShortcutLocalization = {
-  en: Shortcuts;
-  [locale: string]: Partial<Shortcuts>;
-};
-
 const SHORTCUT_LOCALISATION = {
   en: {
     yes: "y",

--- a/src/offTaxonomy.ts
+++ b/src/offTaxonomy.ts
@@ -1,6 +1,4 @@
-import axios, { AxiosResponse } from "axios";
-
-type TagType = "categories" | "labels" | "brands";
+import axios from "axios";
 
 export type TaxonomyItem = {
   /**

--- a/src/pages/Brandinator/index.tsx
+++ b/src/pages/Brandinator/index.tsx
@@ -19,7 +19,7 @@ export default function BrandinatorPage() {
   const [filter, setFilter] = React.useState<[number, number]>([1.2, 4.3]);
 
   const handleFilterChage = (
-    event: Event,
+    _event: Event,
     newValue: number | [number, number],
   ) => {
     if (!Array.isArray(newValue)) {

--- a/src/pages/home/homeCards.jsx
+++ b/src/pages/home/homeCards.jsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import Card from "@mui/material/Card";

--- a/src/pages/ingredients/IngeredientDisplay.tsx
+++ b/src/pages/ingredients/IngeredientDisplay.tsx
@@ -69,37 +69,45 @@ function ColorText({
     ({ ingredients, ...ingredient }) => [ingredient, ...(ingredients || [])],
   );
 
-  let lastIndex = 0;
-
-  return [
-    ...flattendIngredients.map((ingredient, i) => {
+  const { parts, lastIndex } = flattendIngredients.reduce<{
+    parts: React.ReactNode[];
+    lastIndex: number;
+  }>(
+    (accumulator, ingredient, i) => {
       // Don't ask me why OFF use this specific character
       const ingredientText = ingredient.text.replace("‚", ",").toLowerCase();
 
-      const startIndex = text.toLowerCase().indexOf(ingredientText, lastIndex);
+      const startIndex = text
+        .toLowerCase()
+        .indexOf(ingredientText, accumulator.lastIndex);
       if (startIndex < 0) {
-        return null;
+        return accumulator;
       }
       const endIndex = startIndex + ingredient.text.length;
 
-      const prefix = text.slice(lastIndex, startIndex);
+      const prefix = text.slice(accumulator.lastIndex, startIndex);
       const ingredientName = text.slice(startIndex, endIndex);
-      lastIndex = endIndex;
 
-      return (
-        <React.Fragment key={i}>
-          <span>{prefix}</span>
+      return {
+        lastIndex: endIndex,
+        parts: [
+          ...accumulator.parts,
+          <React.Fragment key={i}>
+            <span>{prefix}</span>
 
-          <Tooltip title={getTitle(ingredient)} enterDelay={500}>
-            <span style={{ color: getColor(ingredient) }}>
-              {ingredientName}
-            </span>
-          </Tooltip>
-        </React.Fragment>
-      );
-    }),
-    text.slice(lastIndex, text.length),
-  ];
+            <Tooltip title={getTitle(ingredient)} enterDelay={500}>
+              <span style={{ color: getColor(ingredient) }}>
+                {ingredientName}
+              </span>
+            </Tooltip>
+          </React.Fragment>,
+        ],
+      };
+    },
+    { parts: [], lastIndex: 0 },
+  );
+
+  return [...parts, text.slice(lastIndex, text.length)];
 }
 
 export function useIngredientParsing() {

--- a/src/pages/ingredients/index.tsx
+++ b/src/pages/ingredients/index.tsx
@@ -9,8 +9,6 @@ import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
 import Link from "@mui/material/Link";
-import TextField from "@mui/material/TextField";
-import MenuItem from "@mui/material/MenuItem";
 import { useCountry } from "../../contexts/CountryProvider";
 import { MapInteractionCSS } from "react-map-interaction";
 
@@ -32,7 +30,7 @@ function ProductInterface(props) {
     setImageTab(selectedImages[0].countryCode);
   }, [selectedImages]);
 
-  const handleChange = (event: React.SyntheticEvent, newValue: string) => {
+  const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
     setImageTab(newValue);
   };
 

--- a/src/pages/ingredients/useData.tsx
+++ b/src/pages/ingredients/useData.tsx
@@ -52,7 +52,7 @@ const formatData = ({
     .filter((key) => key.startsWith("ingredients"))
     .map((key) => {
       const imageData = images[key];
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
       const [_, x, y] = images[key].geometry.split("-");
 
       const countryCode = key.startsWith("ingredients_")

--- a/src/pages/insights/InsightsGrid.jsx
+++ b/src/pages/insights/InsightsGrid.jsx
@@ -136,6 +136,7 @@ const InsightGrid = ({ filterState = {}, setFilterState }) => {
         type: "actions",
         getActions: (params) => [
           <GridActionsCellItem
+            key="edit"
             component="a"
             href={getProductEditUrl(params.row.barcode)}
             label={t("insights.edit_product")}
@@ -146,6 +147,7 @@ const InsightGrid = ({ filterState = {}, setFilterState }) => {
             }
           />,
           <GridActionsCellItem
+            key="view"
             component="a"
             href={getProductUrl(params.row.barcode)}
             label={t("insights.view_product")}
@@ -156,6 +158,7 @@ const InsightGrid = ({ filterState = {}, setFilterState }) => {
             }
           />,
           <GridActionsCellItem
+            key="crops"
             component="a"
             href={getLogoCropsByBarcodeUrl(params.row.barcode)}
             label={t("insights.view_crops_for_this_product")}

--- a/src/pages/logos/LogoDeepSearch.jsx
+++ b/src/pages/logos/LogoDeepSearch.jsx
@@ -131,7 +131,7 @@ export default function LogoSearch() {
           ];
         });
         // eslint-disable-next-line no-empty
-      } catch (error) {}
+      } catch {}
     };
 
     setIsLoadingAnnotatedLogos(true);

--- a/src/pages/logos/ProductLogoAnnotations.jsx
+++ b/src/pages/logos/ProductLogoAnnotations.jsx
@@ -45,7 +45,7 @@ const fetchProducts = async ({ page, filter }) => {
       count,
       codes: products.map((x) => x.code),
     };
-  } catch (error) {
+  } catch {
     return {
       count: 0,
       codes: [],

--- a/src/pages/logosValidator/DashBoard.tsx
+++ b/src/pages/logosValidator/DashBoard.tsx
@@ -75,7 +75,7 @@ export default function VerticalTabs() {
     DASHBOARD.findIndex(({ tag }) => tag === dasboardId) || 0,
   );
 
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+  const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
 
@@ -115,7 +115,7 @@ export default function VerticalTabs() {
             />
           ))}
         </Tabs>
-        {DASHBOARD.map(({ tag, title }, index) => (
+        {DASHBOARD.map((_, index) => (
           <TabPanel value={value} key={index} index={index} />
         ))}
       </Box>

--- a/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionValidator.tsx
+++ b/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionValidator.tsx
@@ -194,7 +194,7 @@ function LogoQuestionValidator() {
           <Slider
             aria-label={t("nutriscore.image_sizes")}
             value={imageSize}
-            onChangeCommitted={(event, newValue) =>
+            onChangeCommitted={(_event, newValue) =>
               setControlledState((prev: any) => ({
                 ...prev,
                 imageSize: newValue,

--- a/src/pages/logosValidator/LogoQuestionValidator/NoMoreLogos.tsx
+++ b/src/pages/logosValidator/LogoQuestionValidator/NoMoreLogos.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@mui/material/Button";

--- a/src/pages/nutrition/index.tsx
+++ b/src/pages/nutrition/index.tsx
@@ -50,7 +50,7 @@ export default function Nutrition() {
         <Box sx={{ mb: 2, px: 2 }}>
           <Autocomplete<CountryOption>
             value={selectedCountry}
-            onChange={(event, newValue) => {
+            onChange={(_event, newValue) => {
               setCountry(newValue?.countryCode || "", "page");
             }}
             options={countries}

--- a/src/pages/packaging/Row.tsx
+++ b/src/pages/packaging/Row.tsx
@@ -41,7 +41,7 @@ const CustomAutoComplet = (props: CustomProps) => {
       options={options}
       value={value}
       onChange={onChange}
-      onInputChange={(event, newInputValue) => setInputValue(newInputValue)}
+      onInputChange={(_event, newInputValue) => setInputValue(newInputValue)}
       disablePortal
       renderInput={(params) => <TextField {...params} />}
       getOptionLabel={(option) =>
@@ -138,7 +138,7 @@ const Row = (props) => {
         <CustomAutoComplet
           options={packagingShapes}
           value={innerShape}
-          onChange={(event, newValue) => {
+          onChange={(_event, newValue) => {
             updateRow({ shape: newValue && newValue.value });
             setInnerShape(newValue);
           }}
@@ -149,7 +149,7 @@ const Row = (props) => {
         <CustomAutoComplet
           options={packagingMaterials}
           value={innerMaterial}
-          onChange={(event, newValue) => {
+          onChange={(_event, newValue) => {
             updateRow({ material: newValue && newValue.value });
             setInnerMaterial(newValue);
           }}
@@ -160,7 +160,7 @@ const Row = (props) => {
         <CustomAutoComplet
           options={packagingRecycling}
           value={innerRecycling}
-          onChange={(event, newValue) => {
+          onChange={(_event, newValue) => {
             updateRow({ recycling: newValue && newValue.value });
             setInnerRecycling(newValue);
           }}

--- a/src/pages/questions/FilterDialog.tsx
+++ b/src/pages/questions/FilterDialog.tsx
@@ -176,7 +176,7 @@ export default function FilterDialog(props: FilterDialogProps) {
           )}
           <Autocomplete
             value={innerCountryObject}
-            onChange={(event, newValue) => setInnerCountryObject(newValue)}
+            onChange={(_event, newValue) => setInnerCountryObject(newValue)}
             options={countries}
             getOptionLabel={(country) => country.label}
             isOptionEqualToValue={(country, value) => country.id === value.id}

--- a/src/pages/questions/SimilarQuestions.tsx
+++ b/src/pages/questions/SimilarQuestions.tsx
@@ -18,7 +18,9 @@ export function SimilarQuestions({
   const { t } = useTranslation();
 
   const valueTag = filterState.valueTag || "";
-  const prefixlessTag = valueTag.includes(":") ? valueTag.substring(valueTag.indexOf(":") + 1) : null;
+  const prefixlessTag = valueTag.includes(":")
+    ? valueTag.substring(valueTag.indexOf(":") + 1)
+    : null;
 
   const { data: similars, isPending } = useQuery({
     queryKey: ["taxonomy", filterState.insightType, valueTag],
@@ -94,8 +96,8 @@ function LabelWithNumber({ tag }: { tag: string }) {
         {status === "pending"
           ? "..."
           : t("questions.remaining_questions_count", {
-            count: count !== undefined && count >= 99 ? "100+" : count ?? 0,
-          })}
+              count: count !== undefined && count >= 99 ? "100+" : (count ?? 0),
+            })}
       </a>
     </li>
   );

--- a/src/pages/questions/UserData.tsx
+++ b/src/pages/questions/UserData.tsx
@@ -41,7 +41,10 @@ const UserData = () => {
     <Box>
       <Stack spacing={1}>
         <Typography sx={{ my: 2 }}>
-          {t("questions.remaining_annotations")}: {questionsCount !== null && questionsCount >= 99 ? "100+" : (questionsCount ?? 0)}
+          {t("questions.remaining_annotations")}:{" "}
+          {questionsCount !== null && questionsCount >= 99
+            ? "100+"
+            : (questionsCount ?? 0)}
         </Typography>
         {recentAnswers.map(
           ({ insight_id, barcode, value, insight_type, answer }) => (

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import QuestionFilter from "../../components/QuestionFilter";
 import QuestionDisplay from "./QuestionDisplay";
 import ProductInformation from "./ProductInformation";

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -131,7 +131,7 @@ const robotoff = {
         count,
         campaigns,
         countries: country,
-      }) as Parameters<Robotoff["insights"]>[0],
+      }),
     );
   },
 


### PR DESCRIPTION
## Summary

- format the two files identified by Prettier
- remove unused imports, variables, callback parameters, and an obsolete ESLint suppression
- add missing JSX keys and remove unnecessary type assertions
- resolve isolated correctness rules around error causes, method binding, JSX children, string narrowing, and render-time mutation

## Results

- Prettier passes
- production build passes
- all Day 1 scoped findings are resolved
- ESLint baseline reduced from 575 errors / 6 warnings to 530 errors / 5 warnings

The remaining findings are intentionally left for the later type-safety, effect, promise, and module-boundary issues.

## Verification

- `yarn exec prettier --check .`
- `yarn build`
- focused ESLint JSON audit confirming zero Day 1 scoped findings

Closes #1606
Part of #1604
