### PR TITLE
refactor: establish typed data boundaries

### DIFF
--- a/src/hooks/useOptions.ts
+++ b/src/hooks/useOptions.ts
@@ -10,12 +10,20 @@ export type Option = {
 
 type Files = "packaging_materials" | "packaging_recycling" | "packaging_shapes";
 
+type TaxonomyEntry = {
+  synonyms: Record<string, string[] | undefined>;
+};
+
+type TaxonomyResponse = Record<string, TaxonomyEntry>;
+
 export const useOptions = (fileName: Files, lang: string) => {
   const [options, setOptions] = React.useState<Option[]>([]);
 
   React.useEffect(() => {
     axios
-      .get(`https://static.${OFF_DOMAIN}/data/taxonomies/${fileName}.full.json`)
+      .get<TaxonomyResponse>(
+        `https://static.${OFF_DOMAIN}/data/taxonomies/${fileName}.full.json`,
+      )
       .then(({ data }) => {
         const newOptions: Option[] = Object.keys(data)
           .map((key) => {

--- a/src/localeStorageManager.ts
+++ b/src/localeStorageManager.ts
@@ -28,34 +28,67 @@ export const localSettingsKeys = {
   showDatabase: "showDatabase",
   showNutriscore: "showNutriscore",
   pageCustomization: "pageCustomization",
+} as const;
+
+type VisiblePages = Record<string, boolean | undefined>;
+
+interface LocalSettings {
+  lang: string;
+  colorMode: "light" | "dark";
+  devMode: boolean;
+  visiblePages: VisiblePages;
+  questions_hideImages: boolean;
+  showTour: boolean;
+  showDatabase: boolean;
+  showNutriscore: boolean;
+  pageCustomization: {
+    questionPage?: {
+      showDebug?: boolean;
+      showOtherQuestions?: boolean;
+    };
+  };
+}
+
+type LocalSettingsKey = keyof LocalSettings;
+
+const parseStoredObject = (value: string | null): Record<string, unknown> => {
+  if (value === null) {
+    return {};
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch (error: unknown) {
+    console.error(error);
+    return {};
+  }
 };
 
 export const localSettings = {
-  fetch: function <T>(): Record<string, T | undefined> {
-    let storedValue = {};
-
-    try {
-      storedValue = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
-    } catch (error: any) {
-      console.error(error);
-      /* empty */
-    }
-
-    return typeof storedValue === "object" ? storedValue : {};
+  fetch(): Partial<LocalSettings> {
+    return parseStoredObject(localStorage.getItem(STORAGE_KEY));
   },
 
-  save: function <T>(settings: T): void {
+  save(settings: Partial<LocalSettings>): void {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
   },
-  update: function <T>(key: string, value: T): void {
-    const settings = this.fetch<T>();
+  update<Key extends LocalSettingsKey>(
+    key: Key,
+    value: LocalSettings[Key],
+  ): void {
+    const settings = this.fetch();
     settings[key] = value;
     this.save(settings);
   },
 };
 
 export const getIsDevMode = (): boolean => {
-  const settings = localSettings.fetch<boolean | undefined>();
+  const settings = localSettings.fetch();
   return settings[localSettingsKeys.isDevMode] ?? false;
 };
 
@@ -63,9 +96,7 @@ export const getVisiblePages: () => {
   nutriscore: boolean;
   insights: boolean;
 } = () => {
-  const settings = localSettings.fetch<
-    undefined | Record<string, boolean | undefined>
-  >();
+  const settings = localSettings.fetch();
   return {
     nutriscore: true,
     insights: true,
@@ -108,7 +139,7 @@ export const getLang = () => {
   }
 
   // 2. Check local storage
-  const settings = localSettings.fetch<string | undefined>();
+  const settings = localSettings.fetch();
   const settingsLanguage = settings[localSettingsKeys.language];
   if (settingsLanguage) {
     return settingsLanguage;
@@ -123,7 +154,7 @@ export const getLang = () => {
 };
 
 export const getStoredColorPreference = (): "light" | "dark" | undefined => {
-  const settings = localSettings.fetch<"light" | "dark">();
+  const settings = localSettings.fetch();
   return settings[localSettingsKeys.colorMode];
 };
 
@@ -141,20 +172,27 @@ export const getColor = (): "light" | "dark" => {
 
 const FAVORITE_STORAGE_KEY = "hunger-game-favorites";
 
+interface FavoriteQuestion {
+  filterState: FilterState;
+  imageSrc?: string;
+  title: string;
+}
+
+interface Favorites {
+  questions: FavoriteQuestion[];
+}
+
 export const localFavorites = {
-  mem: null,
-  fetch: function () {
-    return JSON.parse(localStorage.getItem(FAVORITE_STORAGE_KEY) || "{}");
+  mem: null as Favorites | null,
+  fetch(): Partial<Favorites> {
+    return parseStoredObject(localStorage.getItem(FAVORITE_STORAGE_KEY));
   },
-  save: function (favorites) {
+  save(favorites: Favorites) {
     localStorage.setItem(FAVORITE_STORAGE_KEY, JSON.stringify(favorites));
   },
-  addQuestion: function (filterState, imageSrc, title) {
+  addQuestion(filterState: FilterState, imageSrc: string, title: string) {
     if (this.mem == null) {
-      this.mem = this.fetch();
-    }
-    if (!this.mem.questions) {
-      this.mem.questions = [];
+      this.mem = { questions: this.fetch().questions ?? [] };
     }
 
     const questionIndex = this.mem.questions.findIndex(
@@ -188,12 +226,9 @@ export const localFavorites = {
     }
     this.save(this.mem);
   },
-  removeQuestion: function (filterState) {
+  removeQuestion(filterState: FilterState) {
     if (this.mem == null) {
-      this.mem = this.fetch();
-    }
-    if (!this.mem.questions) {
-      return;
+      this.mem = { questions: this.fetch().questions ?? [] };
     }
     this.mem.questions = this.mem.questions.filter(
       ({ filterState: memFilterState }) =>
@@ -201,13 +236,9 @@ export const localFavorites = {
     );
     this.save(this.mem);
   },
-  isSaved: function (filterState) {
+  isSaved(filterState: FilterState) {
     if (this.mem == null) {
-      this.mem = this.fetch();
-    }
-
-    if (!this.mem.questions) {
-      return false;
+      this.mem = { questions: this.fetch().questions ?? [] };
     }
 
     return (

--- a/src/off.ts
+++ b/src/off.ts
@@ -1,4 +1,7 @@
-import { OpenFoodFacts } from "@openfoodfacts/openfoodfacts-nodejs";
+import {
+  OpenFoodFacts,
+  type Product as SdkProduct,
+} from "@openfoodfacts/openfoodfacts-nodejs";
 import { getLang } from "./localeStorageManager";
 import {
   OFF_DOMAIN,
@@ -13,17 +16,21 @@ import axios from "axios";
 
 const BARCODE_REGEX = /(...)(...)(...)(.*)$/;
 
-interface Product {
-  product_name?: string;
-  brands?: string[];
-  ingredients_text?: string;
-  countries_tags?: string[];
-  images?: any;
-  categories?: string[];
-  categories_tags?: string[];
-  labels_tags?: string;
-  quantity?: string;
-}
+export type ProductImage = { uploaded_t?: number } & Record<string, unknown>;
+
+export type Product = Pick<
+  SdkProduct,
+  | "product_name"
+  | "brands"
+  | "ingredients_text"
+  | "countries_tags"
+  | "categories"
+  | "categories_tags"
+  | "labels_tags"
+  | "quantity"
+> & {
+  images?: Record<string, ProductImage | string>;
+};
 
 export const offClient = new OpenFoodFacts(
   (input: RequestInfo | URL, init: RequestInit | undefined) =>

--- a/src/offTaxonomy.ts
+++ b/src/offTaxonomy.ts
@@ -48,10 +48,10 @@ export default async function getTaxonomy(
     return {};
   }
   return await axios
-    .get(
+    .get<Record<string, TaxonomyItem>>(
       `https://world.openfoodfacts.org/api/v2/taxonomy?tagtype=${tagtype}&tags=${tag}${
         languages && languages.length > 0 ? `&lc=${languages.join(",")}` : ""
       }`,
     )
-    .then((response) => response.data);
+    .then(({ data }) => data);
 }

--- a/src/pages/questions/ProductInformation.tsx
+++ b/src/pages/questions/ProductInformation.tsx
@@ -43,13 +43,14 @@ import {
 } from "./utils";
 import useQuestions from "../../hooks/useQuestions";
 import { useProductData } from "../../hooks/useProduct";
+import type { Product } from "../../off";
 import { Skeleton } from "@mui/material";
 
 const ProductImagesGrid = ({
   images,
   barcode,
 }: {
-  images: Record<string, { uploaded_t: number }>;
+  images: NonNullable<Product["images"]>;
   barcode: string;
 }) => {
   const { t } = useTranslation();
@@ -140,6 +141,8 @@ const ProductInfoTable = ({
 }) => {
   const { t } = useTranslation();
   const theme = useTheme();
+  const isStringArray = (value: unknown): value is string[] =>
+    Array.isArray(value) && value.every((item) => typeof item === "string");
 
   function ProductInfoRow({
     product,
@@ -158,7 +161,7 @@ const ProductInfoTable = ({
     const isMissing =
       value == null ||
       (typeof value === "string" && value.trim() === "") ||
-      (Array.isArray(value) && value.length === 0);
+      (isStringArray(value) && value.length === 0);
 
     if (isMissing) {
       return (
@@ -190,7 +193,7 @@ const ProductInfoTable = ({
         <TableCell component="th" scope="row">
           {t(`questions.${i18nKey}`)}
         </TableCell>
-        {Array.isArray(value) ? (
+        {isStringArray(value) ? (
           <TableCell
             sx={{
               "& a": {

--- a/src/pages/questions/utils.ts
+++ b/src/pages/questions/utils.ts
@@ -1,5 +1,6 @@
 import { NO_QUESTION_LEFT, OFF_DOMAIN, OFF_URL } from "../../const";
 import offService from "../../off";
+import type { Product } from "../../off";
 import robotoff, { QuestionInterface } from "../../robotoff";
 import { reformatValueTag } from "../../utils";
 import { FilterState } from "../../robotoff";
@@ -55,7 +56,7 @@ const getUploadedTime = (data: number) =>
   });
 
 export const getImagesUrls = (
-  images: Record<string, { uploaded_t: number }>,
+  images: NonNullable<Product["images"]>,
   barcode: string,
 ) => {
   if (!images || !barcode) {
@@ -65,11 +66,17 @@ export const getImagesUrls = (
   const rootImageUrl = offService.getImageUrl(formattedCode);
   return Object.keys(images)
     .filter((key) => !isNaN(Number.parseInt(key)))
-    .map((key) => ({
-      imageUrl: `${rootImageUrl}/${key}.400.jpg`,
-      imageUrlFull: `${rootImageUrl}/${key}.jpg`,
-      uploaded_t: getUploadedTime(images[key].uploaded_t),
-    }));
+    .map((key) => {
+      const image = images[key];
+      return {
+        imageUrl: `${rootImageUrl}/${key}.400.jpg`,
+        imageUrlFull: `${rootImageUrl}/${key}.jpg`,
+        uploaded_t:
+          typeof image === "object" && image.uploaded_t !== undefined
+            ? getUploadedTime(image.uploaded_t)
+            : "Unknown",
+      };
+    });
 };
 
 export const getFullSizeImage = (src?: string) => {


### PR DESCRIPTION
## Summary

- define typed schemas for persisted settings and favorite questions
- parse persisted JSON through an unknown/object boundary instead of propagating any
- derive the product contract from the Open Food Facts SDK Product type
- add a narrow local image extension for fields not represented precisely by the SDK
- type taxonomy and packaging-option HTTP responses
- narrow unknown product information before rendering links

## SDK usage

The Open Food Facts SDK remains the source of truth where it exposes concrete contracts. The existing Robotoff wrapper already derives annotation and insight request types from SDK methods. Local contracts are retained only where the current SDK exposes Record<string, unknown> or any, notably detailed questions, logos, and image metadata.

## Results

- ESLint errors reduced from 530 to 476
- warnings remain at 5
- Prettier passes
- production build passes

Feature-specific unsafe operations remain assigned to the later packaging, ingredients, logos, and shared-component issues.

## Verification

- `yarn exec prettier --check .`
- `yarn build`
- full ESLint JSON baseline comparison

Closes #1607
Part of #1604
