### PR TITLE
Lint cleanup: type packaging annotation flow

### DIFF
--- a/src/pages/packaging/Row.tsx
+++ b/src/pages/packaging/Row.tsx
@@ -4,20 +4,16 @@ import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
-import { Option } from "../../hooks/useOptions";
+import type { Option } from "../../hooks/useOptions";
+import type { EditablePackaging, PackagingUpdate } from "./useBuffer";
 
 type CustomProps = {
   options: Option[];
   value: Option | null;
-  onChange: any;
+  onChange: (value: Option | null) => void;
 };
 
-/**
- * Returns true if motif is included in one syn
- * @param synonyms
- * @param motif
- */
-const firstSynonymMatching = (synonyms, motif) => {
+const firstSynonymMatching = (synonyms: string[], motif: string) => {
   const normalizedMotif = motif
     .toLowerCase()
     .normalize("NFD")
@@ -32,100 +28,70 @@ const firstSynonymMatching = (synonyms, motif) => {
   });
 };
 
-const CustomAutoComplet = (props: CustomProps) => {
+const CustomAutoComplete = ({ options, value, onChange }: CustomProps) => {
   const [inputValue, setInputValue] = React.useState("");
-  const { options, value, onChange } = props;
 
   return (
     <Autocomplete
       options={options}
       value={value}
-      onChange={onChange}
+      onChange={(_event, newValue) => onChange(newValue)}
       onInputChange={(_event, newInputValue) => setInputValue(newInputValue)}
       disablePortal
       renderInput={(params) => <TextField {...params} />}
       getOptionLabel={(option) =>
-        typeof option === "string"
-          ? option
-          : firstSynonymMatching(option?.synonyms, inputValue)
+        firstSynonymMatching(option.synonyms, inputValue) ?? option.label
       }
-      filterOptions={(options) => {
-        return options.filter(
+      filterOptions={(availableOptions) =>
+        availableOptions.filter(
           (option) => firstSynonymMatching(option.synonyms, inputValue) != null,
-        );
-      }}
-      isOptionEqualToValue={(option, value) => option.value === value.value}
+        )
+      }
+      isOptionEqualToValue={(option, selected) =>
+        option.value === selected.value
+      }
     />
   );
 };
 
-const getOption = (options: Option[], key: string | null) => {
-  if (!key) {
-    return null;
-  }
-  const index = options.findIndex((option) => option.value === key);
+const getOption = (options: Option[], key: string | null) =>
+  options.find((option) => option.value === key) ?? null;
 
-  if (index >= 0) {
-    return options[index];
-  }
-  return null;
+type RowProps = EditablePackaging & {
+  packagingMaterials: Option[];
+  packagingShapes: Option[];
+  packagingRecycling: Option[];
+  updateRow: (update: PackagingUpdate) => void;
 };
 
-const Row = (props) => {
-  const {
-    packagingMaterials,
-    packagingShapes,
-    packagingRecycling,
-    updateRow,
-    material = null,
-    number_of_units: number = null,
-    recycling = null,
-    shape = null,
-  } = props;
-
-  const [innerMaterial, setInnerMaterial] = React.useState(() =>
-    getOption(packagingMaterials, material),
-  );
-  React.useEffect(() => {
-    setInnerMaterial(getOption(packagingMaterials, material));
-  }, [material, packagingMaterials]);
-
+const Row = ({
+  packagingMaterials,
+  packagingShapes,
+  packagingRecycling,
+  updateRow,
+  material,
+  number,
+  recycling,
+  shape,
+}: RowProps) => {
+  const [innerMaterial, setInnerMaterial] = React.useState(material);
   const [innerNumber, setInnerNumber] = React.useState(number);
-  React.useEffect(() => {
-    setInnerNumber(number);
-  }, [number]);
-
-  const [innerRecycling, setInnerRecycling] = React.useState(() =>
-    getOption(packagingRecycling, recycling),
-  );
-  React.useEffect(() => {
-    setInnerRecycling(getOption(packagingRecycling, recycling));
-  }, [packagingRecycling, recycling]);
-
-  const [innerShape, setInnerShape] = React.useState(() =>
-    getOption(packagingShapes, shape),
-  );
-  React.useEffect(() => {
-    setInnerShape(getOption(packagingShapes, shape));
-  }, [packagingShapes, shape]);
+  const [innerRecycling, setInnerRecycling] = React.useState(recycling);
+  const [innerShape, setInnerShape] = React.useState(shape);
 
   const reset = () => {
-    setInnerMaterial(getOption(packagingMaterials, material));
-    setInnerRecycling(getOption(packagingRecycling, recycling));
-    setInnerShape(getOption(packagingShapes, shape));
+    setInnerMaterial(material);
+    setInnerRecycling(recycling);
+    setInnerShape(shape);
     setInnerNumber(number);
-    updateRow({
-      material,
-      number,
-      recycling,
-      shape,
-    });
+    updateRow({ material, number, recycling, shape });
   };
+
   return (
     <TableRow>
       <TableCell>
         <TextField
-          value={innerNumber || ""}
+          value={innerNumber}
           onChange={(event) => {
             setInnerNumber(event.target.value);
             updateRow({ number: event.target.value });
@@ -135,34 +101,37 @@ const Row = (props) => {
       </TableCell>
 
       <TableCell>
-        <CustomAutoComplet
+        <CustomAutoComplete
           options={packagingShapes}
-          value={innerShape}
-          onChange={(_event, newValue) => {
-            updateRow({ shape: newValue && newValue.value });
-            setInnerShape(newValue);
+          value={getOption(packagingShapes, innerShape)}
+          onChange={(newValue) => {
+            const value = newValue?.value ?? null;
+            updateRow({ shape: value });
+            setInnerShape(value);
           }}
         />
       </TableCell>
 
       <TableCell>
-        <CustomAutoComplet
+        <CustomAutoComplete
           options={packagingMaterials}
-          value={innerMaterial}
-          onChange={(_event, newValue) => {
-            updateRow({ material: newValue && newValue.value });
-            setInnerMaterial(newValue);
+          value={getOption(packagingMaterials, innerMaterial)}
+          onChange={(newValue) => {
+            const value = newValue?.value ?? null;
+            updateRow({ material: value });
+            setInnerMaterial(value);
           }}
         />
       </TableCell>
 
       <TableCell>
-        <CustomAutoComplet
+        <CustomAutoComplete
           options={packagingRecycling}
-          value={innerRecycling}
-          onChange={(_event, newValue) => {
-            updateRow({ recycling: newValue && newValue.value });
-            setInnerRecycling(newValue);
+          value={getOption(packagingRecycling, innerRecycling)}
+          onChange={(newValue) => {
+            const value = newValue?.value ?? null;
+            updateRow({ recycling: value });
+            setInnerRecycling(value);
           }}
         />
       </TableCell>

--- a/src/pages/packaging/index.tsx
+++ b/src/pages/packaging/index.tsx
@@ -270,12 +270,23 @@ const Page = () => {
         : "",
   };
 
-  const [data, next] = useBuffer({
+  const [data, next, error, retry] = useBuffer({
     ...searchState,
     country: countryId,
   });
 
   const product = data?.[0] ?? null;
+  if (error !== null) {
+    return (
+      <Stack spacing={2} alignItems="flex-start">
+        <Typography color="error">Unable to load a product: {error}</Typography>
+        <Button variant="contained" onClick={retry}>
+          Retry
+        </Button>
+      </Stack>
+    );
+  }
+
   if (product === null) {
     return <p>Loading...</p>;
   }

--- a/src/pages/packaging/index.tsx
+++ b/src/pages/packaging/index.tsx
@@ -19,7 +19,12 @@ import VisibilityIcon from "@mui/icons-material/Visibility";
 import axios from "axios";
 
 import Row from "./Row";
-import { useBuffer } from "./useBuffer";
+import {
+  useBuffer,
+  type EditablePackaging,
+  type PackagingUpdate,
+  type ProductDescription,
+} from "./useBuffer";
 import { useOptions } from "../../hooks/useOptions";
 import { getLang } from "../../localeStorageManager";
 import ZoomableImage from "../../components/ZoomableImage";
@@ -31,22 +36,29 @@ import useUrlParams from "../../hooks/useUrlParams";
 import Loader from "../loader";
 import { useCountry } from "../../contexts/CountryProvider";
 import { getCountryId } from "../../utils/getCountryId";
-const formatData = (innerRows) => {
+type PackagingWrite = {
+  number_of_units?: number;
+  shape?: { id: string };
+  material?: { id: string };
+  recycling?: { id: string };
+};
+
+const formatData = (innerRows: EditablePackaging[]) => {
   const packagings = innerRows
     .map(({ material, number, recycling, shape }) => {
-      const rep = {};
+      const rep: PackagingWrite = {};
 
       if (number && !isNaN(Number.parseInt(number))) {
-        rep["number_of_units"] = Number.parseInt(number);
+        rep.number_of_units = Number.parseInt(number);
       }
       if (shape) {
-        rep[`shape`] = { id: shape };
+        rep.shape = { id: shape };
       }
       if (material) {
-        rep[`material`] = { id: material };
+        rep.material = { id: material };
       }
       if (recycling) {
-        rep[`recycling`] = { id: recycling };
+        rep.recycling = { id: recycling };
       }
 
       if (Object.keys(rep).length > 0) {
@@ -62,70 +74,84 @@ const formatData = (innerRows) => {
   return { product: { fields: "updated", packagings } };
 };
 
-const Page = () => {
-  const [country] = useCountry();
-  const countryId = React.useMemo(
-    () => getCountryId(country) || "en:france",
-    [country],
-  );
+const toEditablePackaging = (
+  product: ProductDescription,
+): EditablePackaging[] =>
+  (product.packagings ?? []).map((packaging, id) => ({
+    id,
+    material: packaging.material?.id ?? null,
+    number: packaging.number_of_units?.toString() ?? "",
+    recycling: packaging.recycling?.id ?? null,
+    shape: packaging.shape?.id ?? null,
+  }));
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+type PackagingEditorProps = {
+  product: ProductDescription;
+  next: () => void;
+  packagingMaterials: ReturnType<typeof useOptions>;
+  packagingShapes: ReturnType<typeof useOptions>;
+  packagingRecycling: ReturnType<typeof useOptions>;
+};
+
+const PackagingEditor = ({
+  product,
+  next,
+  packagingMaterials,
+  packagingShapes,
+  packagingRecycling,
+}: PackagingEditorProps) => {
   const { t } = useTranslation();
-  const lang = getLang();
-  const packagingMaterials = useOptions("packaging_materials", lang);
-  const packagingShapes = useOptions("packaging_shapes", lang);
-  const packagingRecycling = useOptions("packaging_recycling", lang);
-  const [searchState] = useUrlParams(
-    {
-      creator: undefined,
-      code: "",
-    },
-    {},
+  const initialRows = React.useMemo(
+    () => toEditablePackaging(product),
+    [product],
   );
+  const [rows, setRows] = React.useState(initialRows);
+  const [innerRows, setInnerRows] = React.useState(initialRows);
 
-  const [rows, setRows] = React.useState([]);
-  const [innerRows, setInnerRows] = React.useState([]);
+  const updateRow = (id: number, update: PackagingUpdate) => {
+    setInnerRows((previous) =>
+      previous.map((row) => (row.id === id ? { ...row, ...update } : row)),
+    );
+  };
 
-  const [data, next] = useBuffer({
-    ...searchState,
-    country: countryId,
-  });
+  const addRow = () => {
+    const id = Math.max(-1, ...rows.map((row) => row.id)) + 1;
+    const newRow: EditablePackaging = {
+      id,
+      material: null,
+      number: "",
+      recycling: null,
+      shape: null,
+    };
+    setRows((previous) => [...previous, newRow]);
+    setInnerRows((previous) => [...previous, newRow]);
+  };
 
-  const product = data?.[0] ?? null;
-  React.useEffect(() => {
-    if (product) {
-      const newRows = product.packagings.map((item, index) => ({
-        id: index,
-        ...item,
-      }));
-      setRows(newRows);
-      setInnerRows(newRows);
-    }
-  }, [product]);
-
-  if (product === null) {
-    return <p>Loading...</p>;
-  }
   return (
     <React.Suspense fallback={<Loader />}>
       <Stack direction="row" spacing={1} sx={{ overflow: "auto" }}>
-        {getImagesUrls(product.images, product.code).map((src) => (
-          <ZoomableImage
-            key={src}
-            src={src}
-            imageProps={{
-              loading: "lazy",
-              style: { maxWidth: 300, maxHeight: 300 },
-            }}
-          />
-        ))}
+        {getImagesUrls(product.images, product.code).map(
+          ({ imageUrl, imageUrlFull }) => (
+            <ZoomableImage
+              key={imageUrl}
+              src={imageUrl}
+              srcFull={imageUrlFull}
+              imageProps={{
+                loading: "lazy",
+                style: { maxWidth: 300, maxHeight: 300 },
+              }}
+            />
+          ),
+        )}
       </Stack>
 
       <Box>
         <Stack
           spacing={1}
-          alignItems={{
-            xs: "flex-start",
-            md: "flex-end",
-          }}
+          alignItems={{ xs: "flex-start", md: "flex-end" }}
           direction={{ xs: "column", md: "row" }}
         >
           <img src={product.image_packaging_url} alt="" />
@@ -134,11 +160,8 @@ const Page = () => {
               <TableHead>
                 <TableRow>
                   <TableCell sx={{ width: 100 }}>Nb per unit</TableCell>
-
                   <TableCell>Shape</TableCell>
-
                   <TableCell>Material</TableCell>
-
                   <TableCell>Recycling</TableCell>
                 </TableRow>
               </TableHead>
@@ -149,47 +172,13 @@ const Page = () => {
                     packagingMaterials={packagingMaterials}
                     packagingShapes={packagingShapes}
                     packagingRecycling={packagingRecycling}
-                    updateRow={(toUpsert) => {
-                      setInnerRows((prev) => {
-                        return prev.map((r) => {
-                          if (r.id !== row.id) {
-                            return r;
-                          }
-                          return { ...r, ...toUpsert };
-                        });
-                      });
-                    }}
+                    updateRow={(update) => updateRow(row.id, update)}
                     {...row}
                   />
                 ))}
               </TableBody>
             </Table>
-            <Button
-              onClick={() => {
-                setRows((prev) => [
-                  ...prev,
-                  {
-                    id: prev.length + 1,
-                    material: null,
-                    number: null,
-                    recycling: null,
-                    shape: null,
-                  },
-                ]);
-                setInnerRows((prev) => [
-                  ...prev,
-                  {
-                    id: prev.length + 1,
-                    material: null,
-                    number: null,
-                    recycling: null,
-                    shape: null,
-                  },
-                ]);
-              }}
-            >
-              Add row
-            </Button>
+            <Button onClick={addRow}>Add row</Button>
           </TableContainer>
         </Stack>
         <Stack
@@ -197,22 +186,22 @@ const Page = () => {
           spacing={2}
           sx={{ my: 2, justifyContent: "flex-end" }}
         >
-          <Button
-            sx={{ width: 150 }}
-            onClick={() => next()}
-            variant="contained"
-          >
+          <Button sx={{ width: 150 }} onClick={next} variant="contained">
             Skip
           </Button>
           <Button
             sx={{ width: 150 }}
             onClick={() => {
-              axios.patch(
-                `${OFF_API_URL_V3}/product/${product.code}`,
-                formatData(innerRows),
-                { withCredentials: true },
-              );
-              next();
+              void axios
+                .patch(
+                  `${OFF_API_URL_V3}/product/${product.code}`,
+                  formatData(innerRows),
+                  { withCredentials: true },
+                )
+                .then(next)
+                .catch((error: unknown) => {
+                  console.error(error);
+                });
             }}
             variant="contained"
             color="success"
@@ -222,7 +211,7 @@ const Page = () => {
         </Stack>
       </Box>
       <Stack direction="row" spacing={2}>
-        <Typography>{product?.product_name}</Typography>
+        <Typography>{product.product_name}</Typography>
         <Button
           size="small"
           component={Link}
@@ -247,6 +236,58 @@ const Page = () => {
         </Button>
       </Stack>
     </React.Suspense>
+  );
+};
+
+const Page = () => {
+  const [country] = useCountry();
+  const countryId = React.useMemo(
+    () => getCountryId(country) || "en:france",
+    [country],
+  );
+  const lang = getLang();
+  const packagingMaterials = useOptions("packaging_materials", lang);
+  const packagingShapes = useOptions("packaging_shapes", lang);
+  const packagingRecycling = useOptions("packaging_recycling", lang);
+  const urlParamsResult: unknown = useUrlParams(
+    {
+      creator: undefined,
+      code: "",
+    },
+    {},
+  );
+  const rawSearchState = Array.isArray(urlParamsResult)
+    ? (urlParamsResult[0] as unknown)
+    : null;
+  const searchState = {
+    creator:
+      isRecord(rawSearchState) && typeof rawSearchState.creator === "string"
+        ? rawSearchState.creator
+        : undefined,
+    code:
+      isRecord(rawSearchState) && typeof rawSearchState.code === "string"
+        ? rawSearchState.code
+        : "",
+  };
+
+  const [data, next] = useBuffer({
+    ...searchState,
+    country: countryId,
+  });
+
+  const product = data?.[0] ?? null;
+  if (product === null) {
+    return <p>Loading...</p>;
+  }
+  return (
+    <PackagingEditor
+      key={product.code}
+      product={product}
+      next={next}
+      packagingMaterials={packagingMaterials}
+      packagingShapes={packagingShapes}
+      packagingRecycling={packagingRecycling}
+    />
   );
 };
 

--- a/src/pages/packaging/useBuffer.ts
+++ b/src/pages/packaging/useBuffer.ts
@@ -1,6 +1,8 @@
+import type { ProductV3 } from "@openfoodfacts/openfoodfacts-nodejs";
 import axios from "axios";
 import * as React from "react";
 import { OFF_SEARCH, OFF_API_URL_V3 } from "../../const";
+import type { ProductImage } from "../../off";
 
 type Parameters = {
   page: number;
@@ -9,23 +11,38 @@ type Parameters = {
   code?: string;
 };
 
-type Packaging = {
-  material: string;
+export type EditablePackaging = {
+  id: number;
+  material: string | null;
   number: string;
-  recycling: string;
-  shape: string;
+  recycling: string | null;
+  shape: string | null;
 };
 
-type ProductDescription = {
-  code: number;
-  states: any;
-  lang: string;
-  image_packaging_url: string;
-  packagings: Packaging[];
-  product_name: string;
-  images: any;
-  creator: string;
+export type PackagingUpdate = Partial<Omit<EditablePackaging, "id">>;
+
+export type ProductDescription = Pick<
+  ProductV3,
+  "code" | "image_packaging_url" | "packagings" | "product_name"
+> & {
+  code: string;
+  images: Record<string, ProductImage | string>;
 };
+
+type SearchResponse = {
+  products?: ProductDescription[];
+  product?: ProductDescription;
+  count?: number;
+  page_size?: number;
+};
+
+type BufferState = {
+  data: ProductDescription[] | null;
+  maxPage: number;
+  page: number;
+  searchKey: string;
+};
+
 function getProductsToAnnotateUrl({
   page = 1,
   country = "en:france",
@@ -57,43 +74,63 @@ export const useBuffer = ({
   country,
   creator,
   code,
-}: Omit<Parameters, "page">): [ProductDescription[], () => void] => {
-  const [page, setPage] = React.useState(() => Math.ceil(Math.random() * 100));
-  const [data, setData] = React.useState<ProductDescription[]>(null);
-  const [maxPage, setMaxPage] = React.useState<number>(100);
+}: Omit<Parameters, "page">): [ProductDescription[] | null, () => void] => {
+  const searchKey = `${country ?? ""}:${creator ?? ""}:${code ?? ""}`;
+  const [state, setState] = React.useState<BufferState>(() => ({
+    data: null,
+    maxPage: 100,
+    page: Math.ceil(Math.random() * 100),
+    searchKey,
+  }));
 
-  const url = getProductsToAnnotateUrl({ page, country, creator, code });
+  if (state.searchKey !== searchKey) {
+    setState({ data: null, maxPage: 100, page: 1, searchKey });
+  }
 
-  const canReset = React.useRef(false);
-  React.useEffect(() => {
-    if (canReset.current) {
-      setData([]);
-      setPage(1);
-    }
-  }, [country, creator]);
-
-  React.useEffect(() => {
-    if (data != null && data.length === 0) {
-      setPage((p) => Math.min(maxPage, p + 1));
-    }
-  }, [data, maxPage]);
+  const activeState =
+    state.searchKey === searchKey
+      ? state
+      : { data: null, maxPage: 100, page: 1, searchKey };
+  const url = getProductsToAnnotateUrl({
+    page: activeState.page,
+    country,
+    creator,
+    code,
+  });
 
   React.useEffect(() => {
     let isValid = true;
-    axios.get(url).then(({ data }) => {
-      if (isValid) {
-        const products = data.products ?? [data.product];
-        setData(products);
-        setMaxPage(Math.floor(data.count / data.page_size) + 1);
-        canReset.current = true;
-      }
-    });
+    void axios
+      .get<SearchResponse>(url)
+      .then(({ data }) => {
+        if (!isValid) {
+          return;
+        }
+        const products = data.products ?? (data.product ? [data.product] : []);
+        const pageSize = data.page_size ?? 1;
+        const maxPage = Math.max(1, Math.ceil((data.count ?? 0) / pageSize));
+        setState((previous) => ({ ...previous, data: products, maxPage }));
+      })
+      .catch((error: unknown) => {
+        console.error(error);
+      });
     return () => {
       isValid = false;
     };
-  }, [url, country]);
+  }, [url]);
 
-  const next = () =>
-    setData((prev) => (prev && prev.length > 0 ? prev.slice(1) : prev));
-  return [data, next];
+  const next = () => {
+    setState((previous) => {
+      if (previous.data && previous.data.length > 1) {
+        return { ...previous, data: previous.data.slice(1) };
+      }
+      return {
+        ...previous,
+        data: null,
+        page: Math.min(previous.maxPage, previous.page + 1),
+      };
+    });
+  };
+
+  return [activeState.data, next];
 };

--- a/src/pages/packaging/useBuffer.ts
+++ b/src/pages/packaging/useBuffer.ts
@@ -38,10 +38,19 @@ type SearchResponse = {
 
 type BufferState = {
   data: ProductDescription[] | null;
+  error: string | null;
   maxPage: number;
   page: number;
+  requestId: number;
   searchKey: string;
 };
+
+type BufferResult = [
+  ProductDescription[] | null,
+  () => void,
+  string | null,
+  () => void,
+];
 
 function getProductsToAnnotateUrl({
   page = 1,
@@ -74,23 +83,39 @@ export const useBuffer = ({
   country,
   creator,
   code,
-}: Omit<Parameters, "page">): [ProductDescription[] | null, () => void] => {
+}: Omit<Parameters, "page">): BufferResult => {
   const searchKey = `${country ?? ""}:${creator ?? ""}:${code ?? ""}`;
   const [state, setState] = React.useState<BufferState>(() => ({
     data: null,
+    error: null,
     maxPage: 100,
     page: Math.ceil(Math.random() * 100),
+    requestId: 0,
     searchKey,
   }));
 
   if (state.searchKey !== searchKey) {
-    setState({ data: null, maxPage: 100, page: 1, searchKey });
+    setState({
+      data: null,
+      error: null,
+      maxPage: 100,
+      page: 1,
+      requestId: 0,
+      searchKey,
+    });
   }
 
   const activeState =
     state.searchKey === searchKey
       ? state
-      : { data: null, maxPage: 100, page: 1, searchKey };
+      : {
+          data: null,
+          error: null,
+          maxPage: 100,
+          page: 1,
+          requestId: 0,
+          searchKey,
+        };
   const url = getProductsToAnnotateUrl({
     page: activeState.page,
     country,
@@ -109,15 +134,29 @@ export const useBuffer = ({
         const products = data.products ?? (data.product ? [data.product] : []);
         const pageSize = data.page_size ?? 1;
         const maxPage = Math.max(1, Math.ceil((data.count ?? 0) / pageSize));
-        setState((previous) => ({ ...previous, data: products, maxPage }));
+        setState((previous) => ({
+          ...previous,
+          data: products,
+          error: null,
+          maxPage,
+        }));
       })
       .catch((error: unknown) => {
         console.error(error);
+        if (isValid) {
+          setState((previous) => ({
+            ...previous,
+            error:
+              error instanceof Error
+                ? error.message
+                : "The product request failed.",
+          }));
+        }
       });
     return () => {
       isValid = false;
     };
-  }, [url]);
+  }, [url, activeState.requestId]);
 
   const next = () => {
     setState((previous) => {
@@ -127,10 +166,20 @@ export const useBuffer = ({
       return {
         ...previous,
         data: null,
+        error: null,
         page: Math.min(previous.maxPage, previous.page + 1),
       };
     });
   };
 
-  return [activeState.data, next];
+  const retry = () => {
+    setState((previous) => ({
+      ...previous,
+      data: null,
+      error: null,
+      requestId: previous.requestId + 1,
+    }));
+  };
+
+  return [activeState.data, next, activeState.error, retry];
 };


### PR DESCRIPTION
Closes #1608

Part of #1604.

## Summary
- derive packaging and product models from the Open Food Facts SDK types
- normalize API packaging components into a typed editable row model
- type autocomplete values, row updates, URL parameters, and Axios responses
- replace effect-driven row synchronization with a keyed editor and explicit buffer transitions
- wait for a successful packaging update before advancing to the next product
- pass compressed and full image URLs correctly to the packaging image viewer

## Verification
- `yarn eslint src/pages/packaging/Row.tsx src/pages/packaging/index.tsx src/pages/packaging/useBuffer.ts`
- `yarn build`
- `yarn eslint .` → 376 errors, 5 warnings (down from 476 errors, 5 warnings)