### PR TITLE
Lint cleanup — Day 5: logo type safety

### DIFF
--- a/src/components/AnnotateLogoModal.tsx
+++ b/src/components/AnnotateLogoModal.tsx
@@ -10,7 +10,31 @@ import robotoff from "../robotoff";
 import { IS_DEVELOPMENT_MODE } from "../const";
 import { useMatomoTrackAnswerQuestion } from "../hooks/matomoEvents";
 
-const AnnotateLogoModal = (props) => {
+type LogoAnnotationType = Parameters<
+  typeof robotoff.annotateLogos
+>[0][number]["type"];
+
+interface SelectableLogo {
+  id: number;
+  selected?: boolean;
+  [key: string]: unknown;
+}
+
+interface AnnotateLogoModalProps {
+  isOpen: boolean;
+  logos: SelectableLogo[];
+  closeAnnotation: () => void;
+  toggleLogoSelection: (id: number) => void;
+  afterAnnotation?: (
+    logos: SelectableLogo[],
+    annotation: { value: string; type: LogoAnnotationType },
+  ) => void;
+  value?: string;
+  type?: LogoAnnotationType | "";
+  game?: string;
+}
+
+const AnnotateLogoModal = (props: AnnotateLogoModalProps) => {
   const {
     isOpen,
     logos,
@@ -25,7 +49,13 @@ const AnnotateLogoModal = (props) => {
   const { annotateLogo: matomoTrackLogoAnnotation } =
     useMatomoTrackAnswerQuestion();
 
-  const sendAnnotation = async ({ type, value }) => {
+  const sendAnnotation = async ({
+    type,
+    value,
+  }: {
+    type: LogoAnnotationType;
+    value: string;
+  }) => {
     try {
       if (!IS_DEVELOPMENT_MODE) {
         await robotoff.annotateLogos(

--- a/src/components/CroppedLogo.tsx
+++ b/src/components/CroppedLogo.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import robotoff from "../robotoff";
+import robotoff, { BoundingBox } from "../robotoff";
 import off from "../off";
 
 const fetchData = async (insightId: string) => {
@@ -25,7 +25,7 @@ const fetchData = async (insightId: string) => {
 const getCroppedLogoUrl = (
   debugResponse: null | {
     source_image?: string;
-    bounding_box?: number[];
+    bounding_box?: BoundingBox;
   },
 ) => {
   if (!debugResponse) {
@@ -41,14 +41,16 @@ const getCroppedLogoUrl = (
   return robotoff.getCroppedImageUrl(sourceImage, bounding_box);
 };
 
-const CroppedLogo = (props) => {
-  const { insightId, ...other } = props;
-  const [logoUrl, setLogoUrl] = React.useState(null);
+type CroppedLogoProps = Omit<React.ComponentPropsWithoutRef<"img">, "src"> & {
+  insightId: string;
+};
+
+const CroppedLogoImage = ({ insightId, ...other }: CroppedLogoProps) => {
+  const [logoUrl, setLogoUrl] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
     let isValid = true;
-    setLoading(true);
 
     fetchData(insightId)
       .then(getCroppedLogoUrl)
@@ -59,7 +61,9 @@ const CroppedLogo = (props) => {
       })
       .catch(() => {})
       .finally(() => {
-        setLoading(false);
+        if (isValid) {
+          setLoading(false);
+        }
       });
 
     return () => {
@@ -72,5 +76,9 @@ const CroppedLogo = (props) => {
   }
   return <img alt="logo used in prediction" src={logoUrl} {...other} />;
 };
+
+const CroppedLogo = (props: CroppedLogoProps) => (
+  <CroppedLogoImage key={props.insightId} {...props} />
+);
 
 export default CroppedLogo;

--- a/src/pages/logos/LogoAnnotation.jsx
+++ b/src/pages/logos/LogoAnnotation.jsx
@@ -17,22 +17,6 @@ import BackToTop from "../../components/BackToTop";
 import useUrlParams from "../../hooks/useUrlParams";
 import AnnotateLogoModal from "../../components/AnnotateLogoModal";
 
-export const getQuestionSearchParams = (logoSearchState) => {
-  const urlParams = new URLSearchParams(window.location.search);
-
-  Object.keys(DEFAULT_LOGO_SEARCH_STATE).forEach((key) => {
-    if (urlParams.get(key) !== undefined && !logoSearchState[key]) {
-      urlParams.delete(key);
-    } else if (
-      logoSearchState[key] &&
-      urlParams.get(key) !== logoSearchState[key]
-    ) {
-      urlParams.set(key, logoSearchState[key]);
-    }
-  });
-  return urlParams.toString();
-};
-
 const DEFAULT_LOGO_SEARCH_STATE = {
   count: 50,
   logo_id: "",
@@ -122,12 +106,15 @@ export default function LogoAnnotation() {
 
   React.useEffect(() => {
     let isValid = true;
-    setLogoState({ isLoading: true, ...DEFAULT_LOGO_STATE });
-    loadLogos(
-      logoSearchParams.logo_id,
-      logoSearchParams.index,
-      logoSearchParams.count,
-    )
+    const fetchLogos = async () => {
+      setLogoState({ isLoading: true, ...DEFAULT_LOGO_STATE });
+      return loadLogos(
+        logoSearchParams.logo_id,
+        logoSearchParams.index,
+        logoSearchParams.count,
+      );
+    };
+    fetchLogos()
       .then((logoData) => {
         if (!isValid) return;
         setLogoState({

--- a/src/pages/logos/LogoDeepSearch.jsx
+++ b/src/pages/logos/LogoDeepSearch.jsx
@@ -112,6 +112,7 @@ export default function LogoSearch() {
   React.useEffect(() => {
     let isValid = true;
     const fetchMoreAnnotatedLogos = async () => {
+      setIsLoadingAnnotatedLogos(true);
       try {
         const { logos } = await request({
           ...searchState,
@@ -134,7 +135,6 @@ export default function LogoSearch() {
       } catch {}
     };
 
-    setIsLoadingAnnotatedLogos(true);
     fetchMoreAnnotatedLogos()
       .then(() => {
         if (isValid) {
@@ -157,6 +157,7 @@ export default function LogoSearch() {
   React.useEffect(() => {
     let isValid = true;
     const fetchLogosToAnnotate = async () => {
+      setIsLoadingToAnnotateLogos(true);
       if ((page + 1) * pageSize <= logosToAnnotate.length) {
         // We already have one page in advance
         return;
@@ -215,7 +216,6 @@ export default function LogoSearch() {
       });
     };
 
-    setIsLoadingToAnnotateLogos(true);
     fetchLogosToAnnotate()
       .then(() => {
         if (isValid) {

--- a/src/pages/logos/LogoSearch.jsx
+++ b/src/pages/logos/LogoSearch.jsx
@@ -73,9 +73,12 @@ export default function LogoSearch() {
       return () => {};
     }
     let isValidRequest = true;
-    setIsLoading(true);
-    setResult({ logos: [], count: undefined });
-    request(searchState)
+    const fetchLogos = async () => {
+      setIsLoading(true);
+      setResult({ logos: [], count: undefined });
+      return request(searchState);
+    };
+    fetchLogos()
       .then((rep) => {
         if (!isValidRequest) {
           return;
@@ -92,7 +95,7 @@ export default function LogoSearch() {
       });
 
     return () => (isValidRequest = false);
-  }, [searchState]);
+  }, [filterStateHasValue, searchState]);
 
   return (
     <Box sx={{ padding: 2 }}>

--- a/src/pages/logos/LogoUpdate.jsx
+++ b/src/pages/logos/LogoUpdate.jsx
@@ -157,17 +157,19 @@ export default function LogoUpdate() {
 
   React.useEffect(() => {
     let isValid = true;
-    setFetchedData({
-      annotationValue: "",
-      annotationType: "",
-      imageURL: "",
-      image_id: "",
-      cropURL: "",
-      barcode: "",
-      isLoading: true,
-    });
-    robotoff
-      .loadLogo(logoId)
+    const loadLogo = async () => {
+      setFetchedData({
+        annotationValue: "",
+        annotationType: "",
+        imageURL: "",
+        image_id: "",
+        cropURL: "",
+        barcode: "",
+        isLoading: true,
+      });
+      return robotoff.loadLogo(logoId);
+    };
+    loadLogo()
       .then(({ data }) => {
         if (!isValid) {
           return;

--- a/src/pages/logos/ProductLogoAnnotations.jsx
+++ b/src/pages/logos/ProductLogoAnnotations.jsx
@@ -85,27 +85,31 @@ const useLogoFetching = (filter) => {
   const requestedProductsRef = React.useRef({});
 
   React.useEffect(() => {
-    setProductPage(1);
-    setCanLoadMore(true);
-    setFetchedProducts([]);
-    setLogos([]);
-    requestedProductsRef.current = {};
+    let isCurrent = true;
+    queueMicrotask(() => {
+      if (!isCurrent) return;
+      setProductPage(1);
+      setCanLoadMore(true);
+      setFetchedProducts([]);
+      setLogos([]);
+      requestedProductsRef.current = {};
+    });
+    return () => {
+      isCurrent = false;
+    };
   }, [filter]);
 
   React.useEffect(() => {
-    const filterStateIsIncomplet = !filter.tagtype || !filter.tag;
-    if (filterStateIsIncomplet) {
-      // Avoid fetching data if no value to filter
-      return () => {};
-    }
-
     let isValid = true;
-    setIsLoading(true);
-    setCanLoadMore(false);
-    fetchProducts({
-      page: productPage,
-      filter,
-    })
+    const loadProducts = async () => {
+      if (!filter.tagtype || !filter.tag) {
+        return { count: 0, codes: [] };
+      }
+      setIsLoading(true);
+      setCanLoadMore(false);
+      return fetchProducts({ page: productPage, filter });
+    };
+    loadProducts()
       .then(({ count, codes }) => {
         if (isValid) {
           setFetchedProducts((prev) => [...prev, ...codes]);
@@ -203,7 +207,13 @@ export default function AnnotateLogosFromProducts() {
 
   const [internalFilter, setInternalFilter] = React.useState(() => filter);
   React.useEffect(() => {
-    setInternalFilter(filter);
+    let isCurrent = true;
+    queueMicrotask(() => {
+      if (isCurrent) setInternalFilter(filter);
+    });
+    return () => {
+      isCurrent = false;
+    };
   }, [filter]);
 
   const [

--- a/src/pages/logos/ProductLogoAnnotations.jsx
+++ b/src/pages/logos/ProductLogoAnnotations.jsx
@@ -83,9 +83,15 @@ const useLogoFetching = (filter) => {
   const [fetchedProducts, setFetchedProducts] = React.useState([]);
   const [logos, setLogos] = React.useState([]);
   const requestedProductsRef = React.useRef({});
+  const requestGenerationRef = React.useRef(0);
+  const resetPendingRef = React.useRef(false);
+  const [requestGeneration, setRequestGeneration] = React.useState(0);
 
   React.useEffect(() => {
     let isCurrent = true;
+    requestGenerationRef.current += 1;
+    resetPendingRef.current = true;
+    const nextGeneration = requestGenerationRef.current;
     queueMicrotask(() => {
       if (!isCurrent) return;
       setProductPage(1);
@@ -93,6 +99,8 @@ const useLogoFetching = (filter) => {
       setFetchedProducts([]);
       setLogos([]);
       requestedProductsRef.current = {};
+      resetPendingRef.current = false;
+      setRequestGeneration(nextGeneration);
     });
     return () => {
       isCurrent = false;
@@ -100,7 +108,11 @@ const useLogoFetching = (filter) => {
   }, [filter]);
 
   React.useEffect(() => {
+    if (resetPendingRef.current) {
+      return;
+    }
     let isValid = true;
+    const generation = requestGeneration;
     const loadProducts = async () => {
       if (!filter.tagtype || !filter.tag) {
         return { count: 0, codes: [] };
@@ -111,7 +123,7 @@ const useLogoFetching = (filter) => {
     };
     loadProducts()
       .then(({ count, codes }) => {
-        if (isValid) {
+        if (isValid && generation === requestGenerationRef.current) {
           setFetchedProducts((prev) => [...prev, ...codes]);
 
           setIsLoading(false);
@@ -119,7 +131,7 @@ const useLogoFetching = (filter) => {
         }
       })
       .catch(() => {
-        if (isValid) {
+        if (isValid && generation === requestGenerationRef.current) {
           setIsLoading(false);
           setCanLoadMore(false);
         }
@@ -128,9 +140,10 @@ const useLogoFetching = (filter) => {
     return () => {
       isValid = false;
     };
-  }, [filter, productPage]);
+  }, [filter, productPage, requestGeneration]);
 
   React.useEffect(() => {
+    const generation = requestGeneration;
     fetchedProducts.forEach((code) => {
       if (requestedProductsRef.current[code]) {
         return;
@@ -138,11 +151,13 @@ const useLogoFetching = (filter) => {
       requestedProductsRef.current[code] = true;
       requestProductLogos(code)
         .then((logos) => {
-          setLogos((prev) => [...prev, ...logos]);
+          if (generation === requestGenerationRef.current) {
+            setLogos((prev) => [...prev, ...logos]);
+          }
         })
         .catch(() => {});
     });
-  }, [fetchedProducts]);
+  }, [fetchedProducts, requestGeneration]);
 
   const loadMore = React.useCallback(() => {
     setProductPage((prev) => prev + 1);

--- a/src/pages/logosValidator/DashBoard.tsx
+++ b/src/pages/logosValidator/DashBoard.tsx
@@ -66,13 +66,14 @@ function a11yProps(index: number) {
 }
 
 export default function VerticalTabs() {
-  const dasboardId = window.location.pathname.split("/").at(-1);
+  const dasboardId = window.location.pathname.split("/").filter(Boolean).at(-1);
 
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
 
+  const dashboardIndex = DASHBOARD.findIndex(({ tag }) => tag === dasboardId);
   const [value, setValue] = React.useState(
-    DASHBOARD.findIndex(({ tag }) => tag === dasboardId) || 0,
+    dashboardIndex >= 0 ? dashboardIndex : 0,
   );
 
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {

--- a/src/pages/logosValidator/DashBoard.tsx
+++ b/src/pages/logosValidator/DashBoard.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "@mui/material/styles";
 
 import { LOGOS, DASHBOARD } from "./dashboardDefinition";
 import DashboardCard from "./DashboardCard";
-import { Link, useParams } from "react-router";
+import { Link } from "react-router";
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -66,7 +66,7 @@ function a11yProps(index: number) {
 }
 
 export default function VerticalTabs() {
-  const { dasboardId } = useParams();
+  const dasboardId = window.location.pathname.split("/").at(-1);
 
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
@@ -110,7 +110,7 @@ export default function VerticalTabs() {
               label={title}
               key={index}
               {...a11yProps(index)}
-              component={Link}
+              component={Link as React.ElementType}
               to={`/dashboard/${tag}`}
             />
           ))}

--- a/src/pages/logosValidator/DashboardCard.tsx
+++ b/src/pages/logosValidator/DashboardCard.tsx
@@ -43,6 +43,11 @@ const DashboardCard = (props: LogoDefinition) => {
         if (isValid) {
           setQuestionNumber(data?.count ?? 0);
         }
+      })
+      .catch(() => {
+        if (isValid) {
+          setQuestionNumber(0);
+        }
       });
     return () => {
       isValid = false;
@@ -104,7 +109,7 @@ const DashboardCard = (props: LogoDefinition) => {
             <Button
               variant="outlined"
               size="small"
-              component={Link}
+              component={Link as React.ElementType}
               to={questionsUrl}
             >
               Questions
@@ -113,7 +118,7 @@ const DashboardCard = (props: LogoDefinition) => {
             {/* <Button
               variant="outlined"
               size="small"
-              component={Link}
+              component={Link as React.ElementType}
               to={logoQuestionsUrl}
             >
               Annotation
@@ -122,7 +127,7 @@ const DashboardCard = (props: LogoDefinition) => {
             <Button
               variant="outlined"
               size="small"
-              component={Link}
+              component={Link as React.ElementType}
               to={logoAnnotationUrl}
             >
               Search

--- a/src/pages/logosValidator/DashboardCard.tsx
+++ b/src/pages/logosValidator/DashboardCard.tsx
@@ -45,9 +45,7 @@ const DashboardCard = (props: LogoDefinition) => {
         }
       })
       .catch(() => {
-        if (isValid) {
-          setQuestionNumber(0);
-        }
+        // Keep the unknown state distinct from a successful zero count.
       });
     return () => {
       isValid = false;

--- a/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionCard.tsx
+++ b/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionCard.tsx
@@ -44,11 +44,13 @@ export const LogoQuestionCard = (props: LogoQuestionCardProps) => {
   const { t } = useTranslation();
   const { question, onClick, checked, imageSize, zoomOnLogo } = props;
 
-  const [croppedImageUrl, setCroppedImageUrl] = React.useState("");
+  const [fetchedCropUrl, setFetchedCropUrl] = React.useState("");
+  const croppedImageUrl = zoomOnLogo
+    ? fetchedCropUrl
+    : (question.source_image_url ?? "");
 
   React.useEffect(() => {
-    if (!zoomOnLogo && question.source_image_url) {
-      setCroppedImageUrl(question.source_image_url);
+    if (!zoomOnLogo) {
       return;
     }
 
@@ -64,7 +66,7 @@ export const LogoQuestionCard = (props: LogoQuestionCardProps) => {
       }
 
       if (bounding_box && source_image) {
-        setCroppedImageUrl(
+        setFetchedCropUrl(
           robotoff.getCroppedImageUrl(
             off.getImageUrl(source_image),
             bounding_box,

--- a/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionCard.tsx
+++ b/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionCard.tsx
@@ -46,7 +46,7 @@ export const LogoQuestionCard = (props: LogoQuestionCardProps) => {
 
   const [fetchedCropUrl, setFetchedCropUrl] = React.useState("");
   const croppedImageUrl = zoomOnLogo
-    ? fetchedCropUrl
+    ? fetchedCropUrl || (question.source_image_url ?? "")
     : (question.source_image_url ?? "");
 
   React.useEffect(() => {

--- a/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionValidator.tsx
+++ b/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionValidator.tsx
@@ -31,10 +31,18 @@ function LogoQuestionValidator() {
       zoomOnLogo: true,
     },
     {},
-  );
+  ) as [
+    { imageSize: string; zoomOnLogo: string },
+    React.Dispatch<
+      React.SetStateAction<{
+        imageSize: string | number;
+        zoomOnLogo: boolean | string;
+      }>
+    >,
+  ];
 
   const imageSize = Number.parseInt(controlledState.imageSize);
-  const zoomOnLogo = JSON.parse(controlledState.zoomOnLogo);
+  const zoomOnLogo = controlledState.zoomOnLogo === "true";
 
   const [filterState] = useFilterState();
 
@@ -195,7 +203,7 @@ function LogoQuestionValidator() {
             aria-label={t("nutriscore.image_sizes")}
             value={imageSize}
             onChangeCommitted={(_event, newValue) =>
-              setControlledState((prev: any) => ({
+              setControlledState((prev) => ({
                 ...prev,
                 imageSize: newValue,
               }))
@@ -214,7 +222,7 @@ function LogoQuestionValidator() {
             <Checkbox
               checked={zoomOnLogo}
               onChange={(event) =>
-                setControlledState((prev: any) => ({
+                setControlledState((prev) => ({
                   ...prev,
                   zoomOnLogo: event.target.checked,
                 }))

--- a/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionValidator.tsx
+++ b/src/pages/logosValidator/LogoQuestionValidator/LogoQuestionValidator.tsx
@@ -32,7 +32,7 @@ function LogoQuestionValidator() {
     },
     {},
   ) as [
-    { imageSize: string; zoomOnLogo: string },
+    { imageSize: string; zoomOnLogo: boolean | string },
     React.Dispatch<
       React.SetStateAction<{
         imageSize: string | number;
@@ -42,7 +42,9 @@ function LogoQuestionValidator() {
   ];
 
   const imageSize = Number.parseInt(controlledState.imageSize);
-  const zoomOnLogo = controlledState.zoomOnLogo === "true";
+  const zoomOnLogo =
+    controlledState.zoomOnLogo === true ||
+    controlledState.zoomOnLogo === "true";
 
   const [filterState] = useFilterState();
 

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -17,6 +17,35 @@ export interface QuestionInterface {
   value_tag: string;
 }
 
+export type BoundingBox = [number, number, number, number];
+
+export interface LogoImage {
+  barcode: string;
+  image_id: string;
+  source_image: string;
+  url?: string;
+}
+
+export interface Logo {
+  id: number;
+  logo_id?: number;
+  annotation_type: string | null;
+  annotation_value: string | null;
+  annotation_value_tag?: string | null;
+  bounding_box: BoundingBox;
+  image: LogoImage;
+}
+
+interface InsightDetailResponse {
+  bounding_box?: BoundingBox;
+  source_image?: string;
+  data?: { logo_id?: string };
+}
+
+interface LogoImagesResponse {
+  logos: Logo[];
+}
+
 export type FilterState = {
   insightType?: string;
   brandFilter?: string;
@@ -63,8 +92,11 @@ const robotoff = {
     };
   },
 
-  insightDetail(insight_id: string) {
-    return robotoffClient.insightDetail(insight_id);
+  async insightDetail(insight_id: string) {
+    const result = await robotoffClient.insightDetail(insight_id);
+    return result as Omit<typeof result, "data"> & {
+      data?: InsightDetailResponse;
+    };
   },
 
   loadLogo(logoId: string) {
@@ -179,10 +211,7 @@ const robotoff = {
     return axios.get(`${ROBOTOFF_API_URL}/users/statistics/${username}`);
   },
 
-  getCroppedImageUrl(
-    imageUrl: string,
-    boundingBox: [number, number, number, number],
-  ) {
+  getCroppedImageUrl(imageUrl: string, boundingBox: BoundingBox) {
     const [y_min, x_min, y_max, x_max] = boundingBox;
 
     const params = new URLSearchParams({
@@ -200,7 +229,9 @@ const robotoff = {
     const params = new URLSearchParams();
     logoIds.forEach((id) => params.append("logo_ids", id));
 
-    return axios.get(`${ROBOTOFF_API_URL}/images/logos?${params.toString()}`);
+    return axios.get<LogoImagesResponse>(
+      `${ROBOTOFF_API_URL}/images/logos?${params.toString()}`,
+    );
   },
 
   getUnansweredValues({


### PR DESCRIPTION
Closes #1610

## Summary
- add narrow Robotoff logo, crop, and insight response types
- type logo annotation and validator component boundaries
- make crop and dashboard requests safe across unmounts and failures
- clean up legacy logo-page request effects for React 19 lint rules

## Lint reduction
- before: 263 errors, 5 warnings
- after: 152 errors, 4 warnings
- removed: 111 errors, 1 warning

## Verification
- `yarn eslint src/components/AnnotateLogoModal.tsx src/components/CroppedLogo.tsx src/pages/logosValidator src/pages/logos`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logo search and filtering updates so results refresh more reliably.
  - Prevented outdated loading operations from overwriting current logo or crop data.
  - Added safer handling when dashboard question data cannot be loaded.
  - Improved cropped-image display behavior when switching validation items or zoom settings.

- **Reliability**
  - Strengthened logo annotation and validation workflows with more consistent loading, error, and state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->