### PR TITLE
Lint cleanup — Day 6: storage, filters, and shared components

### DIFF
--- a/src/components/Opportunities.tsx
+++ b/src/components/Opportunities.tsx
@@ -8,6 +8,7 @@ import CardContent from "@mui/material/CardContent";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import Button from "@mui/material/Button";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 
 import Loader from "../pages/loader";
 
@@ -18,7 +19,19 @@ import { getLang } from "../localeStorageManager";
 
 const pageSize = 25;
 
-const OpportunityCard = (props) => {
+interface OpportunitiesProps {
+  type: "label" | "brand" | "category";
+  campaign: string;
+  countryCode: string;
+}
+
+interface OpportunityCardProps extends OpportunitiesProps {
+  value: string;
+  name: string;
+  questionNumber: number;
+}
+
+const OpportunityCard = (props: OpportunityCardProps) => {
   const { type, value, name, campaign, countryCode, questionNumber } = props;
 
   const targetUrl = `/questions?${getQuestionSearchParams({
@@ -37,7 +50,11 @@ const OpportunityCard = (props) => {
         }}
         variant="outlined"
       >
-        <CardActionArea component={Link} to={targetUrl} sx={{ height: "100%" }}>
+        <CardActionArea
+          component={Link as React.ElementType}
+          to={targetUrl}
+          sx={{ height: "100%" }}
+        >
           <CardContent>
             <Typography variant="h6">{name}</Typography>
             <Typography sx={{ textAlign: "end", mt: 3, fontSize: "1.5rem" }}>
@@ -70,73 +87,48 @@ const CardSkeleton = () => (
   </React.Suspense>
 );
 
-const useTranslation = (toTranslate) => {
-  const [translation, setTranslation] = React.useState({});
-
-  React.useEffect(() => {
-    const remaining = toTranslate.filter((key) => !translation[key]);
-
-    if (remaining.length > 0) {
-      off
-        .getCategoriesTranslations({ categories: remaining })
-        .then(({ data }) => {
-          setTranslation((prev) => ({
-            ...prev,
-            ...data,
-          }));
-        })
-        .catch(() => {});
-    }
-  }, [toTranslate]);
-
-  return translation;
+const useCategoryTranslations = (categories: string[]) => {
+  const { data } = useQuery({
+    queryKey: ["category-translations", categories],
+    queryFn: async () => {
+      const response = await off.getCategoriesTranslations({ categories });
+      return response.data;
+    },
+    enabled: categories.length > 0,
+  });
+  return data ?? {};
 };
 
-const Opportunities = (props) => {
+const Opportunities = (props: OpportunitiesProps) => {
   const { type, campaign, countryCode } = props;
-  const [remainingQuestions, setRemainingQuestions] = React.useState([]);
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [page, setPage] = React.useState(1);
-
-  React.useEffect(() => {
-    setRemainingQuestions([]);
-  }, [type, campaign, countryCode]);
-
-  React.useEffect(() => {
-    let isValid = true;
-    setIsLoading(true);
-
-    robotoff
-      .getUnansweredValues({
-        type,
-        campaign,
-        countryCode,
-        page,
-        count: pageSize,
-      })
-      .then(({ data }) => {
-        if (isValid) {
-          setRemainingQuestions((prev) => [
-            ...prev,
-            ...(data?.questions ?? []),
-          ]);
-          setIsLoading(false);
-        }
-      })
-      .catch(() => {
-        setIsLoading(false);
-      });
-
-    return () => {
-      isValid = false;
-    };
-  }, [type, campaign, countryCode, page]);
-
-  const translation = useTranslation(
-    remainingQuestions.map(([value]) => value),
+  const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useInfiniteQuery({
+      queryKey: ["opportunities", type, campaign, countryCode],
+      initialPageParam: 1,
+      queryFn: async ({ pageParam }) => {
+        const response = await robotoff.getUnansweredValues({
+          type,
+          campaign,
+          countryCode,
+          page: pageParam,
+          count: pageSize,
+        });
+        return response.data.questions ?? [];
+      },
+      getNextPageParam: (lastPage, pages) =>
+        lastPage.length < pageSize ? undefined : pages.length + 1,
+    });
+  const remainingQuestions = React.useMemo(
+    () => data?.pages.flat() ?? [],
+    [data?.pages],
   );
+  const categories = React.useMemo(
+    () => remainingQuestions.map(([value]) => value),
+    [remainingQuestions],
+  );
+  const translation = useCategoryTranslations(categories);
 
-  const lang = getLang();
+  const lang = getLang() ?? "en";
   return (
     <React.Suspense fallback={<Loader />}>
       <Box sx={{ mt: 2, px: 2 }}>
@@ -167,16 +159,16 @@ const Opportunities = (props) => {
               />
             );
           })}
-          {isLoading &&
+          {(isLoading || isFetchingNextPage) &&
             [
               0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
               19, 20, 21, 22, 23, 24,
             ].map((id) => <CardSkeleton key={id} />)}
           <Button
-            disabled={isLoading}
+            disabled={isLoading || isFetchingNextPage || !hasNextPage}
             variant="contained"
             fullWidth
-            onClick={() => setPage((p) => p + 1)}
+            onClick={() => void fetchNextPage()}
           >
             Load more
           </Button>

--- a/src/components/Opportunities.tsx
+++ b/src/components/Opportunities.tsx
@@ -8,7 +8,7 @@ import CardContent from "@mui/material/CardContent";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import Button from "@mui/material/Button";
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueries } from "@tanstack/react-query";
 
 import Loader from "../pages/loader";
 
@@ -87,16 +87,41 @@ const CardSkeleton = () => (
   </React.Suspense>
 );
 
-const useCategoryTranslations = (categories: string[]) => {
-  const { data } = useQuery({
-    queryKey: ["category-translations", categories],
-    queryFn: async () => {
-      const response = await off.getCategoriesTranslations({ categories });
-      return response.data;
-    },
-    enabled: categories.length > 0,
+type Opportunity = [string, number];
+type CategoryTranslations = Record<
+  string,
+  { name?: Record<string, string | undefined> }
+>;
+
+const useCategoryTranslations = (pages: Opportunity[][]) => {
+  const lang = getLang() ?? "en";
+  const seen = new Set<string>();
+  const categoryPages = pages.map((page) =>
+    page.flatMap(([category]) => {
+      if (seen.has(category)) return [];
+      seen.add(category);
+      return category;
+    }),
+  );
+
+  return useQueries({
+    queries: categoryPages.map((categories) => ({
+      queryKey: ["category-translations", lang, categories],
+      queryFn: async () => {
+        const response = await off.getCategoriesTranslations({ categories });
+        return response.data;
+      },
+      enabled: categories.length > 0,
+    })),
+    combine: (results) =>
+      results.reduce<CategoryTranslations>(
+        (translations, result) => ({
+          ...translations,
+          ...(result.data ?? {}),
+        }),
+        {},
+      ),
   });
-  return data ?? {};
 };
 
 const Opportunities = (props: OpportunitiesProps) => {
@@ -122,11 +147,7 @@ const Opportunities = (props: OpportunitiesProps) => {
     () => data?.pages.flat() ?? [],
     [data?.pages],
   );
-  const categories = React.useMemo(
-    () => remainingQuestions.map(([value]) => value),
-    [remainingQuestions],
-  );
-  const translation = useCategoryTranslations(categories);
+  const translation = useCategoryTranslations(data?.pages ?? []);
 
   const lang = getLang() ?? "en";
   return (

--- a/src/components/QuestionFilter/LabelFilter.tsx
+++ b/src/components/QuestionFilter/LabelFilter.tsx
@@ -32,7 +32,7 @@ const LabelFilter = (props: LabelFilterProps) => {
   const [selection, setSelection] = React.useState<{
     sourceValue: string;
     value: string | TaxonomyOption | null;
-  }>({ sourceValue: value, value: null });
+  }>({ sourceValue: value, value });
   const [inputValue, setInputValue] = React.useState("");
 
   const lang = getLang();

--- a/src/components/QuestionFilter/LabelFilter.tsx
+++ b/src/components/QuestionFilter/LabelFilter.tsx
@@ -29,9 +29,10 @@ interface LabelFilterProps {
 const LabelFilter = (props: LabelFilterProps) => {
   const { showKey, onChange, value, insightType, fullWidth, ...other } = props;
 
-  const [innerValue, setInnerValue] = React.useState<
-    string | TaxonomyOption | null
-  >(null);
+  const [selection, setSelection] = React.useState<{
+    sourceValue: string;
+    value: string | TaxonomyOption | null;
+  }>({ sourceValue: value, value: null });
   const [inputValue, setInputValue] = React.useState("");
 
   const lang = getLang();
@@ -58,26 +59,17 @@ const LabelFilter = (props: LabelFilterProps) => {
     },
   });
 
-  React.useEffect(() => {
-    setInnerValue((prev) => {
-      if (typeof prev === "object" && prev?.id === value) {
-        return prev;
-      }
-      const solution = options?.find((option) => option.id === value);
-
-      if (solution) {
-        return solution;
-      }
-      return value;
-    });
-  }, [value, options]);
+  const innerValue =
+    selection.sourceValue === value
+      ? selection.value
+      : (options?.find((option) => option.id === value) ?? value);
 
   return (
     <Autocomplete
       fullWidth={fullWidth}
       freeSolo
       onChange={(_, newValue) => {
-        setInnerValue(newValue);
+        setSelection({ sourceValue: value, value: newValue });
         onChange(typeof newValue === "object" ? newValue?.id : newValue);
       }}
       onInputChange={(_event, newInputValue) => {
@@ -89,7 +81,7 @@ const LabelFilter = (props: LabelFilterProps) => {
             ? innerValue === inputValue
             : innerValue?.text === inputValue;
         if (!isSelectedValue) {
-          setInnerValue(inputValue);
+          setSelection({ sourceValue: value, value: inputValue });
           onChange(inputValue);
         }
       }}

--- a/src/components/QuestionFilter/useFavorite.ts
+++ b/src/components/QuestionFilter/useFavorite.ts
@@ -5,13 +5,8 @@ import { FilterState } from "../../robotoff";
 export const useFavorite = (
   filterState: FilterState,
 ): [boolean, () => void] => {
-  const [isFavorite, setIsFavorite] = React.useState(
-    localFavorites.isSaved(filterState),
-  );
-
-  React.useEffect(() => {
-    setIsFavorite(localFavorites.isSaved(filterState));
-  }, [filterState]);
+  const [, refreshFavorite] = React.useReducer((value: number) => value + 1, 0);
+  const isFavorite = localFavorites.isSaved(filterState);
 
   const toggleFavorite = React.useCallback(
     (imageSrc = "", title = "") => {
@@ -23,7 +18,7 @@ export const useFavorite = (
         localFavorites.addQuestion(filterState, imageSrc, title);
       }
 
-      setIsFavorite(!isSaved);
+      refreshFavorite();
     },
     [filterState],
   );

--- a/src/components/ResponsiveAppBar.tsx
+++ b/src/components/ResponsiveAppBar.tsx
@@ -116,10 +116,6 @@ const MultiPagesButton = ({
   const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
-  React.useEffect(() => {
-    if (!isOpen) setAnchorEl(null);
-  }, [isOpen]);
-
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
     if (!isOpen) toggleIsOpen();
@@ -153,7 +149,10 @@ const MultiPagesButton = ({
             onClick={handleClose}
             {...(isExternalUrl(subPage.url)
               ? { component: "a", target: "_blank", href: subPage.url }
-              : { component: Link, to: `/${subPage.url}` })}
+              : {
+                  component: Link as React.ElementType,
+                  to: `/${subPage.url}`,
+                })}
           >
             <Typography textAlign="center">
               {t(subPage.translationKey)}
@@ -280,7 +279,10 @@ const ResponsiveAppBar = () => {
                         sx={{ display: "block" }}
                         {...(isExternalUrl(page.url)
                           ? { component: "a", target: "_blank", href: page.url }
-                          : { component: Link, to: `/${page.url}` })}
+                          : {
+                              component: Link as React.ElementType,
+                              to: `/${page.url}`,
+                            })}
                       >
                         <Typography textAlign="left">
                           {t(page.translationKey)}
@@ -325,7 +327,7 @@ const ResponsiveAppBar = () => {
                                 sx={{ pl: 4 }}
                                 key={subPage.translationKey}
                                 onClick={handleCloseNavMenu}
-                                component={Link}
+                                component={Link as React.ElementType}
                                 to={`/${subPage.url}`}
                               >
                                 <Typography textAlign="center">
@@ -361,7 +363,7 @@ const ResponsiveAppBar = () => {
             <Typography
               variant="h5"
               noWrap
-              component={Link}
+              component={Link as React.ElementType}
               to="/"
               sx={{
                 flexGrow: 0,
@@ -379,12 +381,14 @@ const ResponsiveAppBar = () => {
               <AccountCircleIcon color="success" />
             ) : (
               <IconButton
-                onClick={async () => {
-                  const isLoggedIn = await refresh();
-                  if (!isLoggedIn) {
-                    window.open(`${OFF_URL}/cgi/login.pl`, "_blank")?.focus();
-                  }
-                }}
+                onClick={() =>
+                  void (async () => {
+                    const isLoggedIn = await refresh();
+                    if (!isLoggedIn) {
+                      window.open(`${OFF_URL}/cgi/login.pl`, "_blank")?.focus();
+                    }
+                  })()
+                }
               >
                 <AccountCircleIcon color="error" />
               </IconButton>
@@ -422,7 +426,7 @@ const ResponsiveAppBar = () => {
               </MuiLink>
               <Typography
                 variant="h6"
-                component={Link}
+                component={Link as React.ElementType}
                 to="/"
                 sx={{
                   mr: 2,
@@ -457,7 +461,7 @@ const ResponsiveAppBar = () => {
                       key={page.url}
                       onClick={handleCloseNavMenu}
                       sx={{ my: 2, display: "block" }}
-                      component={Link}
+                      component={Link as React.ElementType}
                       to={`/${page.url}`}
                       data-welcome-tour={page.url}
                     >
@@ -527,7 +531,7 @@ const ResponsiveAppBar = () => {
                 color="inherit"
                 onClick={handleCloseNavMenu}
                 sx={{ my: 2 }}
-                component={Link}
+                component={Link as React.ElementType}
                 to={`/settings`}
                 data-welcome-tour="settings"
               >
@@ -553,14 +557,16 @@ const ResponsiveAppBar = () => {
                   <AccountCircleIcon color="success" />
                 ) : (
                   <IconButton
-                    onClick={async () => {
-                      const isLoggedIn = await refresh();
-                      if (!isLoggedIn) {
-                        window
-                          .open(`${OFF_URL}/cgi/login.pl`, "_blank")
-                          ?.focus();
-                      }
-                    }}
+                    onClick={() =>
+                      void (async () => {
+                        const isLoggedIn = await refresh();
+                        if (!isLoggedIn) {
+                          window
+                            .open(`${OFF_URL}/cgi/login.pl`, "_blank")
+                            ?.focus();
+                        }
+                      })()
+                    }
                   >
                     <AccountCircleIcon color="error" />
                   </IconButton>

--- a/src/contexts/CountryProvider/CountryProvider.tsx
+++ b/src/contexts/CountryProvider/CountryProvider.tsx
@@ -7,12 +7,21 @@ import countries from "../../assets/countries.json";
 
 const ValidCountryCodes = new Set(countries.map((c) => c.countryCode));
 
+type SearchParamsSetter = (
+  update: (previous: URLSearchParams) => URLSearchParams,
+) => void;
+
+const useTypedSearchParams = useSearchParams as unknown as () => [
+  URLSearchParams,
+  SearchParamsSetter,
+];
+
 export function CountryProvider({ children }: { children: React.ReactNode }) {
   const [localStorageCountry, setLocalStorageCountry] = useLocalStorageState(
     "country",
     "",
   );
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useTypedSearchParams();
 
   const updateCountry: CountryCallback = React.useCallback(
     (newCountry, scope) => {
@@ -20,9 +29,9 @@ export function CountryProvider({ children }: { children: React.ReactNode }) {
         setLocalStorageCountry(newCountry);
       }
       setSearchParams((prev) => {
-        prev.set("country", newCountry);
-
-        return prev;
+        const next = new URLSearchParams(prev);
+        next.set("country", newCountry);
+        return next;
       });
     },
     [setLocalStorageCountry, setSearchParams],

--- a/src/hooks/useFilterState/useFilterState.ts
+++ b/src/hooks/useFilterState/useFilterState.ts
@@ -3,11 +3,20 @@ import { getFilterParams, setFilterParams } from "./getFilterParams";
 import { FilterState } from "../../robotoff";
 import { useSearchParams } from "react-router";
 
+type SearchParamsSetter = (
+  update: (previous: URLSearchParams) => URLSearchParams,
+) => void;
+
+const useTypedSearchParams = useSearchParams as unknown as () => [
+  URLSearchParams,
+  SearchParamsSetter,
+];
+
 export function useFilterState(): [
   FilterState,
   (params: Partial<FilterState>) => void,
 ] {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useTypedSearchParams();
 
   const value = React.useMemo(() => {
     return getFilterParams(searchParams);

--- a/src/off.ts
+++ b/src/off.ts
@@ -84,7 +84,9 @@ class OffService {
 
   getCategoriesTranslations({ categories }: { categories: string[] }) {
     const lang = getLang();
-    return axios.get(
+    return axios.get<
+      Record<string, { name?: Record<string, string | undefined> }>
+    >(
       `${OFF_API_URL_V2}/taxonomy?tagtype=categories&lc=en%2C${lang}&cc=fr&fields=name,wikidata&tags=${categories.join(
         ",",
       )}`,

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -245,7 +245,7 @@ const robotoff = {
     page?: number;
     count?: number;
   }) {
-    return axios.get(
+    return axios.get<{ questions?: [string, number][] }>(
       `${ROBOTOFF_API_URL}/questions/unanswered/?${Object.entries(
         removeEmptyKeys({
           ...other,


### PR DESCRIPTION
Closes #1611

Stacked on #1621; rebase and retarget to `master` after Day 5 merges.

## Summary
- type router search-param boundaries and make country URL updates immutable
- remove derived-state effects from favorites and taxonomy autocomplete
- handle navigation promises and type router-backed MUI components
- load paginated opportunities and taxonomy translations with React Query
- add narrow shared API response types

## Lint reduction
- before: 152 errors, 4 warnings
- after: 91 errors, 3 warnings
- removed: 61 errors, 1 warning

## Verification
- focused Batch 6 ESLint scope
- `npm run build`
- `git diff --check`