### PR TITLE
Lint cleanup Day 7: remove effect-driven state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -162,7 +162,9 @@ export default function App() {
   }, [userState.isLoggedIn]);
 
   React.useEffect(() => {
-    refresh();
+    Promise.resolve()
+      .then(refresh)
+      .catch(() => {});
   }, [refresh]);
 
   // Matomo page view tracking

--- a/src/components/LogoForm.jsx
+++ b/src/components/LogoForm.jsx
@@ -10,19 +10,7 @@ import { useTranslation } from "react-i18next";
 
 import LabelFilter from "../components/QuestionFilter/LabelFilter";
 import { TYPE_WITHOUT_VALUE } from "../const";
-
-const logoTypeOptions = [
-  { value: "", labelKey: "logos.type" },
-  { value: "label", labelKey: "logos.label" },
-  { value: "brand", labelKey: "logos.brand" },
-  { value: "packager_code", labelKey: "logos.packager_code" },
-  { value: "packaging", labelKey: "logos.packaging" },
-  { value: "qr_code", labelKey: "logos.qr_code" },
-  { value: "category", labelKey: "logos.category" },
-  { value: "nutrition_label", labelKey: "logos.nutrition_label" },
-  { value: "store", labelKey: "logos.store" },
-  { value: "no_logo", labelKey: "logos.no_logo" },
-];
+import { logoTypeOptions } from "./logoTypeOptions";
 
 const isValidAnnotation = ({ type, value }) => {
   if (type?.length === 0) return false;
@@ -42,16 +30,26 @@ const getFormattedValues = ({ type, value }) => {
 
 const useLogoForm = (value, type, request) => {
   const [isSending, setIsSending] = React.useState(false);
-  const [innerValue, setInnerValue] = React.useState(value);
-  const [innerType, setInnerType] = React.useState(type);
+  const [draft, setDraft] = React.useState({
+    sourceValue: value,
+    sourceType: type,
+    value,
+    type,
+  });
+  const isCurrentDraft =
+    draft.sourceValue === value && draft.sourceType === type;
+  const innerValue = isCurrentDraft ? draft.value : value;
+  const innerType = isCurrentDraft ? draft.type : type;
 
-  React.useLayoutEffect(() => {
-    setInnerValue(value);
-  }, [value]);
-
-  React.useLayoutEffect(() => {
-    setInnerType(type);
-  }, [type]);
+  const updateDraft = (changes) => {
+    setDraft({
+      sourceValue: value,
+      sourceType: type,
+      value: innerValue,
+      type: innerType,
+      ...changes,
+    });
+  };
 
   const send = React.useCallback(async () => {
     setIsSending(true);
@@ -75,14 +73,14 @@ const useLogoForm = (value, type, request) => {
 
   const typeControl = {
     value: innerType,
-    onChange: (event) => setInnerType(event.target.value),
+    onChange: (event) => updateDraft({ type: event.target.value }),
   };
   const valueControl = {
     insightType: hasAutoComplet ? innerType : undefined,
     value: innerValue,
     onChange: hasAutoComplet
-      ? (newValue) => setInnerValue(newValue)
-      : (event) => setInnerValue(event.target.value),
+      ? (newValue) => updateDraft({ value: newValue })
+      : (event) => updateDraft({ value: event.target.value }),
   };
 
   return {

--- a/src/components/LogoGrid.jsx
+++ b/src/components/LogoGrid.jsx
@@ -165,20 +165,22 @@ const LogoGrid = (props) => {
     editOpen,
   } = props;
 
-  const [lastClicked, setLastClicked] = React.useState(null);
+  const logoIds = React.useMemo(() => logos.map((logo) => logo.id), [logos]);
+  const logoIdsKey = React.useMemo(() => JSON.stringify(logoIds), [logoIds]);
+  const [selectionAnchor, setSelectionAnchor] = React.useState({
+    logoIdsKey,
+    lastClicked: null,
+  });
+  const lastClicked =
+    selectionAnchor.logoIdsKey === logoIdsKey
+      ? selectionAnchor.lastClicked
+      : null;
+  const setLastClicked = React.useCallback(
+    (nextLastClicked) =>
+      setSelectionAnchor({ logoIdsKey, lastClicked: nextLastClicked }),
+    [logoIdsKey],
+  );
   const selectionApiRef = React.useRef({});
-
-  const [logoIds, setLogoIds] = React.useState([]);
-
-  React.useEffect(() => {
-    if (
-      JSON.stringify(logoIds) !== JSON.stringify(logos.map((logo) => logo.id))
-    ) {
-      // Reset lastClick when logos ret reordered or modified
-      setLogoIds(logos.map((logo) => logo.id));
-      setLastClicked(null);
-    }
-  }, [logoIds, logos]);
 
   React.useEffect(() => {
     selectionApiRef.current = {
@@ -190,6 +192,7 @@ const LogoGrid = (props) => {
         if (lastClicked === null) {
           toggleLogoSelection(id);
           setLastClicked({ selected: !selected, index });
+          return;
         }
 
         const newSelectionState =
@@ -211,7 +214,13 @@ const LogoGrid = (props) => {
         }
       },
     };
-  }, [lastClicked, logoIds, setLogoSelectionRange, toggleLogoSelection]);
+  }, [
+    lastClicked,
+    logoIds,
+    setLastClicked,
+    setLogoSelectionRange,
+    toggleLogoSelection,
+  ]);
 
   return (
     <Box

--- a/src/components/LogoSearchForm.jsx
+++ b/src/components/LogoSearchForm.jsx
@@ -9,20 +9,8 @@ import { useTranslation } from "react-i18next";
 
 import LabelFilter from "../components/QuestionFilter/LabelFilter";
 import { TYPE_WITHOUT_VALUE } from "../const";
+import { logoTypeOptions } from "./logoTypeOptions";
 import TaxonomyAutoSelect from "./TaxonomyAutoSelect";
-
-export const logoTypeOptions = [
-  { value: "", labelKey: "logos.type" },
-  { value: "label", labelKey: "logos.label" },
-  { value: "brand", labelKey: "logos.brand" },
-  { value: "packager_code", labelKey: "logos.packager_code" },
-  { value: "packaging", labelKey: "logos.packaging" },
-  { value: "qr_code", labelKey: "logos.qr_code" },
-  { value: "category", labelKey: "logos.category" },
-  { value: "nutrition_label", labelKey: "logos.nutrition_label" },
-  { value: "store", labelKey: "logos.store" },
-  { value: "no_logo", labelKey: "logos.no_logo" },
-];
 
 const getFormattedValues = ({ type, value, count, barcode }) => {
   let formattedValue = value.toLowerCase().trim();
@@ -38,24 +26,38 @@ const LogoSearchForm = (props) => {
   const { value, barcode, type, count, validate, ...other } = props;
   const { t } = useTranslation();
 
-  const [innerValue, setInnerValue] = React.useState(value);
-  const [innerType, setInnerType] = React.useState(type);
-  const [innerCount, setInnerCount] = React.useState(count);
-  const [innerBarcode, setInnerBarcode] = React.useState(barcode);
-
-  React.useLayoutEffect(() => {
-    setInnerValue(value);
-  }, [value]);
-
-  React.useLayoutEffect(() => {
-    setInnerType(type);
-  }, [type]);
-  React.useLayoutEffect(() => {
-    setInnerBarcode(barcode);
-  }, [barcode]);
-  React.useLayoutEffect(() => {
-    setInnerCount(count);
-  }, [count]);
+  const [draft, setDraft] = React.useState({
+    sourceValue: value,
+    sourceType: type,
+    sourceCount: count,
+    sourceBarcode: barcode,
+    value,
+    type,
+    count,
+    barcode,
+  });
+  const isCurrentDraft =
+    draft.sourceValue === value &&
+    draft.sourceType === type &&
+    draft.sourceCount === count &&
+    draft.sourceBarcode === barcode;
+  const currentDraft = isCurrentDraft ? draft : { value, type, count, barcode };
+  const updateDraft = (changes) => {
+    setDraft({
+      sourceValue: value,
+      sourceType: type,
+      sourceCount: count,
+      sourceBarcode: barcode,
+      ...currentDraft,
+      ...changes,
+    });
+  };
+  const {
+    value: innerValue,
+    type: innerType,
+    count: innerCount,
+    barcode: innerBarcode,
+  } = currentDraft;
 
   return (
     <Stack direction="column" spacing={{ xs: 1, sm: 2, md: 4 }} {...other}>
@@ -63,7 +65,7 @@ const LogoSearchForm = (props) => {
         <TextField
           fullWidth
           value={innerType}
-          onChange={(event) => setInnerType(event.target.value)}
+          onChange={(event) => updateDraft({ type: event.target.value })}
           select
           label={t("logos.type")}
           size="small"
@@ -79,7 +81,7 @@ const LogoSearchForm = (props) => {
             showKey
             fullWidth
             value={innerValue}
-            onChange={setInnerValue}
+            onChange={(newValue) => updateDraft({ value: newValue })}
             insightType={innerType}
             label={t("logos.value")}
             size="small"
@@ -88,7 +90,7 @@ const LogoSearchForm = (props) => {
           <TaxonomyAutoSelect
             taxonomy="brand"
             value={innerValue}
-            onChange={setInnerValue}
+            onChange={(newValue) => updateDraft({ value: newValue })}
             showKey
             fullWidth
             size="small"
@@ -98,7 +100,7 @@ const LogoSearchForm = (props) => {
           <TextField
             fullWidth
             value={innerValue}
-            onChange={(event) => setInnerValue(event.target.value)}
+            onChange={(event) => updateDraft({ value: event.target.value })}
             label={t("logos.value")}
             size="small"
           />
@@ -108,14 +110,14 @@ const LogoSearchForm = (props) => {
         <TextField
           fullWidth
           value={innerBarcode}
-          onChange={(event) => setInnerBarcode(event.target.value)}
+          onChange={(event) => updateDraft({ barcode: event.target.value })}
           label={t("logos.barcode")}
           size="small"
         />
         <TextField
           fullWidth
           value={innerCount}
-          onChange={(event) => setInnerCount(event.target.value)}
+          onChange={(event) => updateDraft({ count: event.target.value })}
           label="Max nb"
           type="number"
           size="small"

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -57,11 +57,10 @@ function EditableCardTitle({
   onSave,
 }: EditableCardTitleProps) {
   const [isEditMode, setIsEditMode] = React.useState(false);
-  const [innerTitle, setInnerTitle] = React.useState(title);
-
-  React.useEffect(() => {
-    setInnerTitle(title);
-  }, [title]);
+  const [titleDraft, setTitleDraft] = React.useState({ source: title, title });
+  const innerTitle = titleDraft.source === title ? titleDraft.title : title;
+  const setInnerTitle = (newTitle: string) =>
+    setTitleDraft({ source: title, title: newTitle });
 
   const handleStartEdit: React.MouseEventHandler = (event) => {
     event.preventDefault();

--- a/src/components/TaxonomyAutoSelect.tsx
+++ b/src/components/TaxonomyAutoSelect.tsx
@@ -27,7 +27,7 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
     props;
   const [inputValue, setInputValue] = React.useState("");
   const [selectedValue, setSelectedValue] = React.useState(null);
-  const [options, setOptions] = React.useState<
+  const [fetchedOptions, setFetchedOptions] = React.useState<
     readonly (string | TaxonomyItem)[]
   >([]);
 
@@ -40,20 +40,21 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
           request: { input: string },
           callback: (results?: readonly TaxonomyItem[]) => void,
         ) => {
-          searchTaxonomy[taxonomy](request.input, language).then(({ data }) => {
-            callback(data?.options ?? []);
-          });
+          searchTaxonomy[taxonomy](request.input, language)
+            .then(({ data }) => {
+              callback(data?.options ?? []);
+            })
+            .catch(() => callback([]));
         },
         400,
       ),
-    [language],
+    [language, taxonomy],
   );
 
   React.useEffect(() => {
     let active = true;
 
     if (inputValue === "") {
-      setOptions(value ? [value] : []);
       return undefined;
     }
 
@@ -69,7 +70,7 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
           newOptions = [...newOptions, ...results];
         }
 
-        setOptions(newOptions);
+        setFetchedOptions(newOptions);
       }
     });
 
@@ -77,6 +78,8 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
       active = false;
     };
   }, [value, inputValue, fetch]);
+
+  const options = inputValue === "" ? (value ? [value] : []) : fetchedOptions;
 
   return (
     <Autocomplete
@@ -94,7 +97,10 @@ export default function TaxonomyAutoSelect(props: TaxonomyAutoSelectProps) {
       }
       isOptionEqualToValue={isOptionEqualToValue}
       // noOptionsText="No locations"
-      onChange={(_event: any, newValue: TaxonomyItem | null | string) => {
+      onChange={(
+        _event: React.SyntheticEvent,
+        newValue: TaxonomyItem | null | string,
+      ) => {
         if (typeof newValue === "object") {
           onChange(newValue.text, newValue);
           setSelectedValue(newValue);

--- a/src/components/ZoomableImage.tsx
+++ b/src/components/ZoomableImage.tsx
@@ -39,18 +39,20 @@ const ZoomableImage = ({
   const apiRef = React.useRef<ReactZoomPanPinchRef>(null);
   const [rotation, setRotation] = React.useState(0);
   const [isOpen, setIsOpen] = React.useState(false);
-  const [showFullResolution, setShowFullResolution] = React.useState(false);
-  const [fullResolutionStatus, setFullResolutionStatus] = React.useState<
-    "none" | "loading" | "available"
-  >("none");
+  const [resolutionState, setResolutionState] = React.useState<{
+    source: string;
+    showFullResolution: boolean;
+    status: "none" | "loading" | "available";
+  }>({ source: src, showFullResolution: false, status: "none" });
+  const currentResolutionState =
+    resolutionState.source === src
+      ? resolutionState
+      : { source: src, showFullResolution: false, status: "none" as const };
+  const { showFullResolution, status: fullResolutionStatus } =
+    currentResolutionState;
   const { t } = useTranslation();
 
   const theme = useTheme();
-
-  React.useEffect(() => {
-    setShowFullResolution(false);
-    setFullResolutionStatus("none");
-  }, [src]);
 
   return (
     <>
@@ -83,8 +85,11 @@ const ZoomableImage = ({
         open={isOpen}
         onClose={() => {
           setIsOpen(false);
-          setShowFullResolution(false);
-          setFullResolutionStatus("none");
+          setResolutionState({
+            source: src,
+            showFullResolution: false,
+            status: "none",
+          });
         }}
         fullScreen
       >
@@ -144,15 +149,25 @@ const ZoomableImage = ({
               variant="outlined"
               onClick={() => {
                 if (!showFullResolution && srcFull) {
-                  setFullResolutionStatus("loading");
+                  setResolutionState({
+                    source: src,
+                    showFullResolution: false,
+                    status: "loading",
+                  });
                   const img = new Image();
                   img.src = srcFull;
                   img.onload = () => {
-                    setFullResolutionStatus("available");
-                    setShowFullResolution(true);
+                    setResolutionState({
+                      source: src,
+                      showFullResolution: true,
+                      status: "available",
+                    });
                   };
                 } else {
-                  setShowFullResolution(false);
+                  setResolutionState({
+                    ...currentResolutionState,
+                    showFullResolution: false,
+                  });
                 }
               }}
               sx={{

--- a/src/components/logoTypeOptions.js
+++ b/src/components/logoTypeOptions.js
@@ -1,0 +1,12 @@
+export const logoTypeOptions = [
+  { value: "", labelKey: "logos.type" },
+  { value: "label", labelKey: "logos.label" },
+  { value: "brand", labelKey: "logos.brand" },
+  { value: "packager_code", labelKey: "logos.packager_code" },
+  { value: "packaging", labelKey: "logos.packaging" },
+  { value: "qr_code", labelKey: "logos.qr_code" },
+  { value: "category", labelKey: "logos.category" },
+  { value: "nutrition_label", labelKey: "logos.nutrition_label" },
+  { value: "store", labelKey: "logos.store" },
+  { value: "no_logo", labelKey: "logos.no_logo" },
+];

--- a/src/components/welcome/Welcome.jsx
+++ b/src/components/welcome/Welcome.jsx
@@ -312,7 +312,7 @@ const Welcome = (props) => {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
 
-  const [isTourOpen, setIsTourOpen] = React.useState(false);
+  const [isTourOpen, setIsTourOpen] = React.useState(getTour);
 
   const handleCloseTour = () => {
     setIsOpen?.(false);
@@ -321,11 +321,10 @@ const Welcome = (props) => {
   };
 
   React.useEffect(() => {
-    if (getTour()) {
-      setIsOpen?.(true);
-      setIsTourOpen(true);
+    if (isTourOpen) {
+      queueMicrotask(() => setIsOpen?.(true));
     }
-  });
+  }, [isTourOpen, setIsOpen]);
 
   const steps = React.useMemo(
     () => getSteps({ t, withSelector: isDesktop, theme }),

--- a/src/hooks/useUrlParams.js
+++ b/src/hooks/useUrlParams.js
@@ -81,21 +81,18 @@ export const convertObjectParamsToUrlParams = (
  * @returns [state, setState]
  */
 const useUrlParams = (defaultParams, synonyms) => {
-  const [parameters, setParameters] = React.useState(() =>
-    getDefaultizedUrlParams(defaultParams),
-  );
   const { search } = useLocation();
-
-  React.useEffect(() => {
-    setParameters((prevParams) => {
-      const newParams = getDefaultizedUrlParams(defaultParams, synonyms);
-
-      const shouldUpdate = Object.keys(defaultParams).some(
-        (key) => newParams[key] !== prevParams[key],
-      );
-      return shouldUpdate ? newParams : prevParams;
-    });
-  }, [search, defaultParams, synonyms]);
+  const sourceKey = `${search}:${JSON.stringify(defaultParams)}:${JSON.stringify(
+    synonyms,
+  )}`;
+  const [parameterState, setParameterState] = React.useState(() => ({
+    sourceKey,
+    parameters: getDefaultizedUrlParams(defaultParams, synonyms),
+  }));
+  const parameters =
+    parameterState.sourceKey === sourceKey
+      ? parameterState.parameters
+      : getDefaultizedUrlParams(defaultParams, synonyms);
 
   const updateParameters = React.useCallback(
     (modifier) => {
@@ -105,10 +102,10 @@ const useUrlParams = (defaultParams, synonyms) => {
       } else {
         newParams = modifier;
       }
-      setParameters(newParams);
+      setParameterState({ sourceKey, parameters: newParams });
       setUrlParams(newParams, defaultParams);
     },
-    [parameters, defaultParams],
+    [parameters, defaultParams, sourceKey],
   );
   return [parameters, updateParameters];
 };

--- a/src/pages/insights/FilterInsights.jsx
+++ b/src/pages/insights/FilterInsights.jsx
@@ -24,11 +24,17 @@ const annotationOptions = [
 ];
 
 const useControled = (exteriorValue) => {
-  const [innerValue, setInnerValue] = React.useState(exteriorValue ?? "");
-
-  React.useEffect(() => {
-    setInnerValue((v) => (v !== exteriorValue ? exteriorValue : v));
-  }, [exteriorValue]);
+  const normalizedExteriorValue = exteriorValue ?? "";
+  const [draft, setDraft] = React.useState({
+    source: normalizedExteriorValue,
+    value: normalizedExteriorValue,
+  });
+  const innerValue =
+    draft.source === normalizedExteriorValue
+      ? draft.value
+      : normalizedExteriorValue;
+  const setInnerValue = (value) =>
+    setDraft({ source: normalizedExteriorValue, value });
 
   return [innerValue, setInnerValue];
 };

--- a/src/pages/insights/InsightsGrid.jsx
+++ b/src/pages/insights/InsightsGrid.jsx
@@ -267,7 +267,7 @@ const InsightGrid = ({ filterState = {}, setFilterState }) => {
       columns={columns}
       rows={rows}
       disableColumnFilter
-      isLoading={insightsQuery.isFetching}
+      loading={insightsQuery.isFetching}
       page={page - 1}
       pageSize={PAGE_SIZE}
       pageSizeOptions={[PAGE_SIZE]}

--- a/src/pages/insights/InsightsGrid.jsx
+++ b/src/pages/insights/InsightsGrid.jsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { DataGrid, GridActionsCellItem } from "@mui/x-data-grid";
 
@@ -125,9 +126,26 @@ const PAGE_SIZE = 25;
 const InsightGrid = ({ filterState = {}, setFilterState }) => {
   const { t } = useTranslation();
 
-  const [pageState, setPageState] = React.useState({ page: 1, rowCount: 0 });
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [rows, setRows] = React.useState([]);
+  const [page, setPage] = React.useState(1);
+  const insightsQuery = useQuery({
+    queryKey: ["insights", filterState, page],
+    queryFn: () =>
+      robotoffService.getInsights(
+        filterState.barcode,
+        filterState.insightType,
+        filterState.valueTag,
+        filterState.annotationStatus,
+        page,
+        PAGE_SIZE,
+      ),
+    placeholderData: (previousData) => previousData,
+  });
+  const rows =
+    insightsQuery.data?.data.insights.map((row) => ({
+      ...row,
+      value_tag: row.value_tag ?? row.value,
+    })) ?? [];
+  const rowCount = insightsQuery.data?.data.count ?? 0;
 
   const columns = React.useMemo(() => {
     return [
@@ -243,67 +261,19 @@ const InsightGrid = ({ filterState = {}, setFilterState }) => {
     ].map((col) => ({ ...col, sortable: false }));
   }, [setFilterState, t]);
 
-  React.useEffect(() => {
-    setIsLoading(true);
-    let isValid = true;
-    robotoffService
-      .getInsights(
-        filterState.barcode,
-        filterState.insightType,
-        filterState.valueTag,
-        filterState.annotationStatus,
-        pageState.page,
-        PAGE_SIZE,
-      )
-      .then((result) => {
-        if (isValid) {
-          const newRowCount = result.data.count;
-          setPageState((prevState) =>
-            newRowCount !== prevState.rowCount
-              ? { ...prevState, rowCount: newRowCount }
-              : prevState,
-          );
-          setRows(
-            result.data.insights.map((row) => ({
-              ...row,
-              value_tag: row.value_tag ?? row.value,
-            })),
-          );
-          setIsLoading(false);
-        }
-      })
-      .catch(() => {
-        if (isValid) {
-          setIsLoading(false);
-        }
-      });
-    return () => {
-      isValid = false;
-    };
-  }, [
-    filterState.barcode,
-    filterState.valueTag,
-    filterState.insightType,
-    filterState.annotationStatus,
-    pageState.page,
-    t,
-  ]);
-
   return (
     <DataGrid
       autoHeight
       columns={columns}
       rows={rows}
       disableColumnFilter
-      isLoading={isLoading}
-      page={pageState.page - 1}
+      isLoading={insightsQuery.isFetching}
+      page={page - 1}
       pageSize={PAGE_SIZE}
       pageSizeOptions={[PAGE_SIZE]}
-      onPageChange={(page) =>
-        setPageState((prev) => ({ ...prev, page: page + 1 }))
-      }
+      onPageChange={(newPage) => setPage(newPage + 1)}
       paginationMode="server"
-      rowCount={pageState.rowCount}
+      rowCount={rowCount}
       density="compact"
       initialState={{
         columns: {

--- a/src/pages/logos/ProductLogoAnnotations.jsx
+++ b/src/pages/logos/ProductLogoAnnotations.jsx
@@ -13,7 +13,7 @@ import Loader from "../loader";
 import LabelFilter from "../../components/QuestionFilter/LabelFilter";
 import LogoGrid from "../../components/LogoGrid";
 import AnnotateLogoModal from "../../components/AnnotateLogoModal";
-import { logoTypeOptions } from "../../components/LogoSearchForm";
+import { logoTypeOptions } from "../../components/logoTypeOptions";
 import robotoff from "../../robotoff";
 import off from "../../off";
 import useUrlParams from "../../hooks/useUrlParams";

--- a/src/pages/nutrition/useNutrimentTranslations.ts
+++ b/src/pages/nutrition/useNutrimentTranslations.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
 
 interface Nutri {
   id?: string;
@@ -28,31 +28,16 @@ function parseNutrients(data: undefined | Nutri[]): Record<string, string> {
 }
 
 export default function useNutrimentTranslations(lc: string) {
-  const [translations, setTranslations] = React.useState<
-    Record<string, Record<string, string>>
-  >({});
+  const query = useQuery({
+    queryKey: ["nutriment-translations", lc],
+    queryFn: async () => {
+      const { data } = await axios.get<{ nutrients?: Nutri[] }>(
+        `https://world.openfoodfacts.org/cgi/nutrients.pl?lc=${lc}`,
+      );
+      return parseNutrients(data.nutrients);
+    },
+    enabled: Boolean(lc && lc !== "en"),
+  });
 
-  React.useEffect(() => {
-    const language = lc;
-    if (
-      !language ||
-      language === "en" ||
-      translations[language] !== undefined
-    ) {
-      return;
-    }
-
-    setTranslations((p) => ({ ...p, [language]: {} }));
-
-    axios
-      .get(`https://world.openfoodfacts.org/cgi/nutrients.pl?lc=${language}`)
-      .then(({ data }) => {
-        setTranslations((p) => ({
-          ...p,
-          [language]: parseNutrients(data.nutrients),
-        }));
-      });
-  }, [lc]);
-
-  return translations;
+  return lc && lc !== "en" ? { [lc]: query.data ?? {} } : {};
 }

--- a/src/pages/questions/FilterDialog.tsx
+++ b/src/pages/questions/FilterDialog.tsx
@@ -117,10 +117,13 @@ export default function FilterDialog(props: FilterDialogProps) {
     onClose,
   ]);
 
-  React.useEffect(resetFilter, [resetFilter]);
-
   return (
-    <Dialog open={open} onClose={onClose} PaperProps={{ sx: { p: 2 } }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { p: 2 } }}
+      TransitionProps={{ onEnter: resetFilter }}
+    >
       <DialogContent>
         <Stack spacing={2} sx={{ display: open ? undefined : "none" }}>
           <FormControl>

--- a/src/pages/questions/ProductOtherQuestions.tsx
+++ b/src/pages/questions/ProductOtherQuestions.tsx
@@ -68,14 +68,18 @@ export default function ProductOtherQuestions({
       pendingAnswer === CORRECT_INSIGHT || pendingAnswer === WRONG_INSIGHT;
     const sendAnswer = valueIsSet
       ? () => {
-          robotoff.annotate(insight_id, pendingAnswer).catch(() => {});
-          setAnswers((prev) => ({
-            ...prev,
-            [insight_id]: {
-              ...prev[insight_id],
-              sent: true,
-            },
-          }));
+          robotoff
+            .annotate(insight_id, pendingAnswer)
+            .then(() => {
+              setAnswers((prev) => ({
+                ...prev,
+                [insight_id]: {
+                  ...prev[insight_id],
+                  sent: true,
+                },
+              }));
+            })
+            .catch(() => {});
         }
       : noop;
 

--- a/src/pages/questions/ProductOtherQuestions.tsx
+++ b/src/pages/questions/ProductOtherQuestions.tsx
@@ -37,21 +37,6 @@ export default function ProductOtherQuestions({
     [data, question.insight_id, answers],
   );
 
-  // Reset the pending answer for new data
-  React.useEffect(() => {
-    if (!data) {
-      return;
-    }
-    setAnswers(
-      Object.fromEntries(
-        data.map((question) => [
-          question.insight_id,
-          { value: null, sent: false },
-        ]),
-      ),
-    );
-  }, [data]);
-
   if (status === "pending") {
     return <Typography>Loading ...</Typography>;
   }
@@ -83,7 +68,7 @@ export default function ProductOtherQuestions({
       pendingAnswer === CORRECT_INSIGHT || pendingAnswer === WRONG_INSIGHT;
     const sendAnswer = valueIsSet
       ? () => {
-          robotoff.annotate(insight_id, pendingAnswer);
+          robotoff.annotate(insight_id, pendingAnswer).catch(() => {});
           setAnswers((prev) => ({
             ...prev,
             [insight_id]: {

--- a/src/pages/questions/QuestionDisplay.tsx
+++ b/src/pages/questions/QuestionDisplay.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/material/styles";
@@ -38,40 +39,21 @@ const usePotentialQuestionNumber = (
   filterState: FilterState,
   question: QuestionInterface | null,
 ) => {
-  const [nbOfPotentialQuestion, setNbOfPotentialQuestions] = React.useState<
-    number | null
-  >(null);
+  const insightType = question?.insight_type;
+  const valueTag = question?.value_tag;
+  const enabled = Boolean(!filterState.valueTag && insightType && valueTag);
+  const query = useQuery({
+    queryKey: ["potential-question-count", filterState, insightType, valueTag],
+    queryFn: () =>
+      getNbOfQuestionForValue({
+        ...filterState,
+        insightType,
+        valueTag,
+      }),
+    enabled,
+  });
 
-  React.useEffect(() => {
-    if (
-      filterState.valueTag ||
-      !question?.insight_type ||
-      !question?.value_tag
-    ) {
-      // value is already in the filter so it's a useless information
-      setNbOfPotentialQuestions(null);
-      return;
-    }
-    let validRequest = true;
-
-    getNbOfQuestionForValue({
-      ...filterState,
-      insightType: question?.insight_type,
-      valueTag: question?.value_tag,
-    })
-      .then((nbQuestions) => {
-        if (validRequest) {
-          setNbOfPotentialQuestions(nbQuestions);
-        }
-      })
-      .catch(() => {});
-
-    return () => {
-      validRequest = false;
-    };
-  }, [filterState, question?.insight_type, question?.value_tag]);
-
-  return nbOfPotentialQuestion;
+  return enabled ? (query.data ?? null) : null;
 };
 
 type AnswerType =
@@ -261,7 +243,7 @@ export default function QuestionDisplay() {
             >
               <Button
                 sx={{ paddingX: 4 }}
-                component={Link}
+                component={Link as React.ElementType}
                 to={valueTagQuestionsURL}
                 endIcon={<LinkIcon />}
                 variant="outlined"

--- a/src/pages/questions/UserData.tsx
+++ b/src/pages/questions/UserData.tsx
@@ -27,15 +27,10 @@ const UserData = () => {
   const { questionsCount, recentAnswers } = useQuestions();
 
   const [loginAlreadyProposed, setLoginAlreadyProposed] = React.useState(false);
-  const [loginModalOpen, setLoginModalOpen] = React.useState(false);
 
   const { isLoggedIn } = React.useContext(LoginContext);
-
-  React.useEffect(() => {
-    if (recentAnswers.length > 3 && !isLoggedIn && !loginAlreadyProposed) {
-      setLoginModalOpen(true);
-    }
-  }, [recentAnswers.length, isLoggedIn, loginAlreadyProposed]);
+  const loginModalOpen =
+    recentAnswers.length > 3 && !isLoggedIn && !loginAlreadyProposed;
 
   return (
     <Box>
@@ -65,7 +60,6 @@ const UserData = () => {
       <Dialog
         open={loginModalOpen}
         onClose={() => {
-          setLoginModalOpen(false);
           setLoginAlreadyProposed(true);
         }}
       >


### PR DESCRIPTION
Closes #1612

## Summary

- replace prop-to-state synchronization effects with source-associated drafts and derived state
- move insights, nutriment translations, and potential question counts to React Query
- move UI resets into interaction boundaries and preserve URL/login/tour synchronization
- extract shared logo type options to keep Fast Refresh boundaries clean

## Results

- `react-hooks/set-state-in-effect`: 20 -> 0
- repository lint: 91 errors and 3 warnings -> 63 errors and 0 warnings

## Validation

- focused ESLint passes for all touched files
- `yarn eslint .` reports 63 existing errors and 0 warnings
- `npm run build` passes
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login refresh and background requests to prevent unhandled errors.
  - Fixed logo selection behavior when switching between logo sets.
  - Improved autocomplete results and error handling.
  - Ensured filters reset correctly when dialogs open.
  - Corrected tour, editable title, image resolution, and login prompt state updates.

- **Improvements**
  - Improved loading, pagination, and cached results for Insights.
  - Improved URL-based filter synchronization.
  - Improved nutrition translation loading for selected languages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->