### PR TITLE
Lint cleanup Day 9: resolve remaining findings

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,17 +1,23 @@
 import * as React from "react";
 
-export class ErrorBoundary extends React.Component {
-  constructor(props) {
+type ErrorBoundaryProps = React.PropsWithChildren;
+type ErrorBoundaryState = { hasError: boolean };
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(_error) {
+  static getDerivedStateFromError(_error: unknown): ErrorBoundaryState {
     // Update state so the next render will show the fallback UI.
     return { hasError: true };
   }
 
-  componentDidCatch(error, info) {
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
     // Example "componentStack":
     //   in ComponentThatThrows (created by App)
     //   in ErrorBoundary (created by App)

--- a/src/components/SmallQuestionCard.tsx
+++ b/src/components/SmallQuestionCard.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import {
   CircularProgress,
@@ -24,23 +24,18 @@ export default function SmallQuestionCard({
 }: SmallQuestionCardProps) {
   const targetUrl = `/questions?${getQuestionSearchParams(filterState)}`;
 
-  const [questionNumber, setQuestionNumber] = React.useState<null | number>(
-    null,
-  );
-
-  React.useEffect(() => {
-    let isValid = true;
-    robotoff
-      .questions({ ...filterState, with_image: true }, 1, 1)
-      .then(({ data }) => {
-        if (isValid) {
-          setQuestionNumber(data?.count ?? 0);
-        }
-      });
-    return () => {
-      isValid = false;
-    };
-  }, [filterState]);
+  const questionCountQuery = useQuery({
+    queryKey: ["question-count", filterState],
+    queryFn: async () => {
+      const { data } = await robotoff.questions(
+        { ...filterState, with_image: true },
+        1,
+        1,
+      );
+      return data?.count ?? 0;
+    },
+  });
+  const questionNumber = questionCountQuery.data ?? null;
 
   return (
     <Badge

--- a/src/contexts/devMode.tsx
+++ b/src/contexts/devMode.tsx
@@ -12,9 +12,9 @@ type DevModeContextType = {
   setVisiblePages: React.Dispatch<
     React.SetStateAction<Record<string, boolean>>
   >;
-  pageCustomization: Record<string, any>;
+  pageCustomization: ReturnType<typeof getPageCustomization>;
   setPageCustomization: React.Dispatch<
-    React.SetStateAction<Record<string, any>>
+    React.SetStateAction<ReturnType<typeof getPageCustomization>>
   >;
 };
 

--- a/src/l10n-shortcuts.ts
+++ b/src/l10n-shortcuts.ts
@@ -6,12 +6,13 @@ type Shortcuts = {
   skip: string;
 };
 
-const SHORTCUT_LOCALISATION = {
-  en: {
-    yes: "y",
-    no: "n",
-    skip: "k",
-  },
+const DEFAULT_SHORTCUTS: Shortcuts = {
+  yes: "y",
+  no: "n",
+  skip: "k",
+};
+
+const SHORTCUT_LOCALISATION: Record<string, Partial<Shortcuts>> = {
   fr: {
     yes: "o",
     no: "n",
@@ -20,8 +21,10 @@ const SHORTCUT_LOCALISATION = {
 };
 
 export const getShortcuts = (lang?: string): Shortcuts => {
+  const localizedShortcuts = SHORTCUT_LOCALISATION[lang ?? getLang() ?? "en"];
   return {
-    ...SHORTCUT_LOCALISATION.en,
-    ...SHORTCUT_LOCALISATION[lang ?? getLang()],
+    yes: localizedShortcuts?.yes ?? DEFAULT_SHORTCUTS.yes,
+    no: localizedShortcuts?.no ?? DEFAULT_SHORTCUTS.no,
+    skip: localizedShortcuts?.skip ?? DEFAULT_SHORTCUTS.skip,
   };
 };

--- a/src/pages/bug/index.tsx
+++ b/src/pages/bug/index.tsx
@@ -1,12 +1,21 @@
 import * as React from "react";
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 import off from "../../off";
 import { TextField } from "@mui/material";
 import { OFF_URL, OFF_API_URL_V3 } from "../../const";
 
 export default function BugPage() {
   const [text, setText] = React.useState("test ingredient values");
-  const [response, setResponse] = React.useState();
+  const [response, setResponse] = React.useState<unknown>();
+  const sendRequest = (request: Promise<AxiosResponse<unknown>>) => {
+    request
+      .then(({ data }) => setResponse(data))
+      .catch((error: unknown) => {
+        setResponse({
+          error: error instanceof Error ? error.message : "Request failed",
+        });
+      });
+  };
 
   return (
     <div>
@@ -26,8 +35,8 @@ export default function BugPage() {
 
       <button
         onClick={() => {
-          axios
-            .post(
+          sendRequest(
+            axios.post<unknown>(
               `${OFF_URL}/cgi/product_jqm2.pl`,
               {
                 code: "123456789",
@@ -39,31 +48,31 @@ export default function BugPage() {
                   "Content-Type": "application/x-www-form-urlencoded",
                 },
               },
-            )
-            .then(({ data }) => setResponse(data));
+            ),
+          );
         }}
       >
         Test jqm2 with credential
       </button>
       <button
         onClick={() => {
-          axios
-            .post(
+          sendRequest(
+            axios.post<unknown>(
               `${OFF_API_URL_V3}/product/123456789`,
               {
                 ingredients_text_fr: text,
               },
               { withCredentials: true },
-            )
-            .then(({ data }) => setResponse(data));
+            ),
+          );
         }}
       >
         Test v3 with credential
       </button>
       <button
         onClick={() => {
-          axios
-            .post(
+          sendRequest(
+            axios.post<unknown>(
               `${OFF_URL}/cgi/product_jqm2.pl`,
               {
                 code: "123456789",
@@ -74,30 +83,30 @@ export default function BugPage() {
                   "Content-Type": "application/x-www-form-urlencoded",
                 },
               },
-            )
-            .then(({ data }) => setResponse(data));
+            ),
+          );
         }}
       >
         Test jqm2 without credential
       </button>
       <button
         onClick={() => {
-          axios
-            .post(`${OFF_API_URL_V3}product/123456789`, {
+          sendRequest(
+            axios.post<unknown>(`${OFF_API_URL_V3}product/123456789`, {
               ingredients_text_fr: text,
-            })
-            .then(({ data }) => setResponse(data));
+            }),
+          );
         }}
       >
         Test v3 without credential
       </button>
       <button
         onClick={() => {
-          axios
-            .patch(`${OFF_API_URL_V3}product/123456789`, {
+          sendRequest(
+            axios.patch<unknown>(`${OFF_API_URL_V3}product/123456789`, {
               ingredients_text_fr: text,
-            })
-            .then(({ data }) => setResponse(data));
+            }),
+          );
         }}
       >
         Test v3 without credential patch

--- a/src/pages/flaggedImages/index.tsx
+++ b/src/pages/flaggedImages/index.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import axios from "axios";
 import { useTranslation } from "react-i18next";
 import Box from "@mui/material/Box";
+import Alert from "@mui/material/Alert";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
@@ -28,6 +29,7 @@ const getImageUrl = (code: string, imgid: number) =>
 export default function FlaggedImages() {
   const { t } = useTranslation();
   const [data, setData] = React.useState<FlaggedImage[] | null>(null);
+  const [deleteError, setDeleteError] = React.useState(false);
 
   React.useEffect(() => {
     axios
@@ -46,6 +48,13 @@ export default function FlaggedImages() {
       <Box>
         <Box sx={{ padding: 2 }}>
           <Typography>{t("flagged_images.title")}</Typography>
+          {deleteError && (
+            <Alert severity="error">
+              {t("flagged_images.delete_error", {
+                defaultValue: "Could not delete the flagged image. Try again.",
+              })}
+            </Alert>
+          )}
           <table>
             {data.map(({ code, imgid }) => (
               <tr key={`${code}-${imgid}`}>
@@ -68,6 +77,7 @@ export default function FlaggedImages() {
                 <td>
                   <IconButton
                     onClick={() => {
+                      setDeleteError(false);
                       axios
                         .delete(flagImageUrl + code, {
                           data: {
@@ -82,7 +92,7 @@ export default function FlaggedImages() {
                             ),
                           );
                         })
-                        .catch(() => {});
+                        .catch(() => setDeleteError(true));
                     }}
                   >
                     <DeleteOutlineIcon

--- a/src/pages/flaggedImages/index.tsx
+++ b/src/pages/flaggedImages/index.tsx
@@ -68,16 +68,21 @@ export default function FlaggedImages() {
                 <td>
                   <IconButton
                     onClick={() => {
-                      axios.delete(flagImageUrl + code, {
-                        data: {
-                          imgid,
-                        },
-                      });
-                      setData((prev) =>
-                        prev.filter(
-                          (line) => line.code !== code || line.imgid !== imgid,
-                        ),
-                      );
+                      axios
+                        .delete(flagImageUrl + code, {
+                          data: {
+                            imgid,
+                          },
+                        })
+                        .then(() => {
+                          setData((prev) =>
+                            prev.filter(
+                              (line) =>
+                                line.code !== code || line.imgid !== imgid,
+                            ),
+                          );
+                        })
+                        .catch(() => {});
                     }}
                   >
                     <DeleteOutlineIcon

--- a/src/pages/nutrition/index.tsx
+++ b/src/pages/nutrition/index.tsx
@@ -21,6 +21,7 @@ interface CountryOption {
 
 const useTypedSearchParams = useSearchParams as unknown as () => [
   URLSearchParams,
+  unknown,
 ];
 
 // Returns true if countryCode is a "valid" country code, i.e. not empty and not "world"

--- a/src/pages/nutrition/index.tsx
+++ b/src/pages/nutrition/index.tsx
@@ -19,6 +19,10 @@ interface CountryOption {
   countryCode: string;
 }
 
+const useTypedSearchParams = useSearchParams as unknown as () => [
+  URLSearchParams,
+];
+
 // Returns true if countryCode is a "valid" country code, i.e. not empty and not "world"
 function isValidCountryCode(
   countryCode?: string | null,
@@ -27,7 +31,7 @@ function isValidCountryCode(
 }
 
 export default function Nutrition() {
-  const [searchParams] = useSearchParams();
+  const [searchParams] = useTypedSearchParams();
   const productCode = searchParams.get("code") || undefined;
   const [country, setCountry] = useCountry();
   const { t } = useTranslation();

--- a/src/pages/nutrition/utils.ts
+++ b/src/pages/nutrition/utils.ts
@@ -60,7 +60,7 @@ export function postRobotoff(config: PostRobotoffParams) {
     }
   });
 
-  axios.post(
+  return axios.post(
     `${ROBOTOFF_API_URL}/insights/annotate`,
     new URLSearchParams(
       `insight_id=${insightId}&annotation=2&data=${JSON.stringify({
@@ -78,7 +78,7 @@ export function postRobotoff(config: PostRobotoffParams) {
 export function skipRobotoff(config: Pick<PostRobotoffParams, "insightId">) {
   const { insightId } = config;
 
-  axios.post(
+  return axios.post(
     `${ROBOTOFF_API_URL}/insights/annotate`,
     new URLSearchParams(`insight_id=${insightId}&annotation=-1`),
     { withCredentials: true },
@@ -88,7 +88,7 @@ export function skipRobotoff(config: Pick<PostRobotoffParams, "insightId">) {
 export function deleteRobotoff(config: Pick<PostRobotoffParams, "insightId">) {
   const { insightId } = config;
 
-  axios.post(
+  return axios.post(
     `${ROBOTOFF_API_URL}/insights/annotate`,
     new URLSearchParams(`insight_id=${insightId}&annotation=0`),
     { withCredentials: true },

--- a/src/pages/questions/QuestionFilter.tsx
+++ b/src/pages/questions/QuestionFilter.tsx
@@ -40,6 +40,17 @@ const useTypedSearchParams = useSearchParams as unknown as () => [
   SearchParamsSetter,
 ];
 
+const updateSearchParams = (
+  setSearchParams: SearchParamsSetter,
+  update: (searchParams: URLSearchParams) => void,
+) => {
+  setSearchParams((previous) => {
+    const next = new URLSearchParams(previous);
+    update(next);
+    return next;
+  });
+};
+
 const getChipsParams = (
   filterState: FilterState,
   setSearchParams: SearchParamsSetter,
@@ -53,10 +64,7 @@ const getChipsParams = (
         "questions.filters.short_label.value",
       )}: ${filterState?.valueTag}`,
       onDelete: () => {
-        setSearchParams((prev) => {
-          prev.delete("value_tag");
-          return prev;
-        });
+        updateSearchParams(setSearchParams, (next) => next.delete("value_tag"));
       },
     },
 
@@ -71,10 +79,7 @@ const getChipsParams = (
         filterState.country,
       )}`,
       onDelete: () => {
-        setSearchParams((prev) => {
-          prev.delete("country");
-          return prev;
-        });
+        updateSearchParams(setSearchParams, (next) => next.delete("country"));
       },
     },
 
@@ -85,10 +90,7 @@ const getChipsParams = (
         "questions.filters.short_label.brand",
       )}: ${filterState.brand}`,
       onDelete: () => {
-        setSearchParams((prev) => {
-          prev.delete("brand");
-          return prev;
-        });
+        updateSearchParams(setSearchParams, (next) => next.delete("brand"));
       },
     },
     {
@@ -96,10 +98,9 @@ const getChipsParams = (
       display: !!filterState.sorted && filterState.sorted !== "false",
       label: t("questions.filters.short_label.popularity"),
       onDelete: () => {
-        setSearchParams((prev) => {
-          prev.set("sorted", "false");
-          return prev;
-        });
+        updateSearchParams(setSearchParams, (next) =>
+          next.set("sorted", "false"),
+        );
       },
     },
     {
@@ -110,10 +111,7 @@ const getChipsParams = (
         "questions.filters.short_label.campaign",
       )}: ${filterState.campaign}`,
       onDelete: () => {
-        setSearchParams((prev) => {
-          prev.delete("campaign");
-          return prev;
-        });
+        updateSearchParams(setSearchParams, (next) => next.delete("campaign"));
       },
     },
     {
@@ -123,10 +121,7 @@ const getChipsParams = (
         "questions.filters.short_label.predictor",
       )}: ${filterState.predictor}`,
       onDelete: () => {
-        setSearchParams((prev) => {
-          prev.delete("predictor");
-          return prev;
-        });
+        updateSearchParams(setSearchParams, (next) => next.delete("predictor"));
       },
     },
   ].filter((item) => item.display);
@@ -160,10 +155,9 @@ export const QuestionFilter = ({ sx }: { sx?: SxProps<Theme> }) => {
           sx={{ width: { xs: "130px", md: 150 } }}
           value={filterState.insightType}
           onChange={(event) =>
-            setSearchParams((prev) => {
-              prev.set("type", event.target.value);
-              return prev;
-            })
+            updateSearchParams(setSearchParams, (next) =>
+              next.set("type", event.target.value),
+            )
           }
           label={t(`questions.insightTypeLabel`)}
         >

--- a/src/pages/questions/QuestionFilter.tsx
+++ b/src/pages/questions/QuestionFilter.tsx
@@ -17,7 +17,7 @@ import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next/typescript/t";
 
-import { SetURLSearchParams, useSearchParams } from "react-router";
+import { useSearchParams } from "react-router";
 
 import { useFavorite } from "../../components/QuestionFilter/useFavorite";
 import {
@@ -31,9 +31,18 @@ import { getFilterParams } from "../../hooks/useFilterState/getFilterParams";
 import { FilterState } from "../../robotoff";
 import { getCountryName } from "../../utils/getCountryName";
 
+type SearchParamsSetter = (
+  update: (previous: URLSearchParams) => URLSearchParams,
+) => void;
+
+const useTypedSearchParams = useSearchParams as unknown as () => [
+  URLSearchParams,
+  SearchParamsSetter,
+];
+
 const getChipsParams = (
   filterState: FilterState,
-  setSearchParams: SetURLSearchParams,
+  setSearchParams: SearchParamsSetter,
   t: TFunction<"translation", undefined>,
 ) =>
   [
@@ -129,7 +138,7 @@ export const QuestionFilter = ({ sx }: { sx?: SxProps<Theme> }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   // Get filter state from search params
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useTypedSearchParams();
   const filterState = React.useMemo(
     () => getFilterParams(searchParams),
     [searchParams],

--- a/src/pages/questions/useKeyboardShortcuts.ts
+++ b/src/pages/questions/useKeyboardShortcuts.ts
@@ -14,8 +14,9 @@ export const useKeyboardShortcuts = (
 
   React.useEffect(() => {
     function handleShortCut(event: KeyboardEvent) {
-      // @ts-expect-error tagName exists on event.target
-      const preventShortCut = event.target?.tagName.toUpperCase() === "INPUT";
+      const preventShortCut =
+        event.target instanceof HTMLElement &&
+        event.target.tagName.toUpperCase() === "INPUT";
       if (question?.insight_id && !preventShortCut) {
         switch (event.key) {
           case shortcuts.skip:

--- a/src/pages/questions/useKeyboardShortcuts.ts
+++ b/src/pages/questions/useKeyboardShortcuts.ts
@@ -14,9 +14,11 @@ export const useKeyboardShortcuts = (
 
   React.useEffect(() => {
     function handleShortCut(event: KeyboardEvent) {
+      const target = event.target;
       const preventShortCut =
-        event.target instanceof HTMLElement &&
-        event.target.tagName.toUpperCase() === "INPUT";
+        target instanceof HTMLElement &&
+        (target.isContentEditable ||
+          ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName));
       if (question?.insight_id && !preventShortCut) {
         switch (event.key) {
           case shortcuts.skip:

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
-const reportWebVitals = async (
-  onPerfEntry: undefined | ((value: unknown) => void) = undefined,
-) => {
+import type { ReportCallback } from "web-vitals";
+
+const reportWebVitals = async (onPerfEntry?: ReportCallback) => {
   if (!onPerfEntry || typeof onPerfEntry !== "function") {
     return;
   }
 
-  const { onCLS, onFID, onFCP, onLCP, onTTFB } = await import("web-vitals");
+  const { onCLS, onFCP, onINP, onLCP, onTTFB } = await import("web-vitals");
 
   onCLS(onPerfEntry);
-  onFID(onPerfEntry);
   onFCP(onPerfEntry);
+  onINP(onPerfEntry);
   onLCP(onPerfEntry);
   onTTFB(onPerfEntry);
 };

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -39,6 +39,9 @@ export interface Logo {
 interface InsightDetailResponse {
   bounding_box?: BoundingBox;
   source_image?: string;
+  id?: string;
+  predictor?: string;
+  timestamp?: string | number;
   data?: { logo_id?: string };
 }
 


### PR DESCRIPTION
Closes #1614

## Summary

- add narrow type boundaries for React Router, error handling, context state, shortcuts, and Robotoff insight data
- move question count loading to React Query
- handle every remaining request promise and preserve UI state on failed deletions
- update web-vitals reporting to the current INP API

## Results

- ESLint: 63 errors and 0 warnings -> 0 errors and 0 warnings

## Validation

- `yarn lint` passes
- `npm run build` passes
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed flagged-image deletions no longer remove images from the list unless the deletion succeeds.
  * Bug-report requests now display a clear response when an error occurs.
  * Keyboard shortcuts no longer interfere incorrectly with text input fields.
  * Nutrition and insight-related requests now handle responses more reliably.

* **Improvements**
  * Question counts now update through more reliable data fetching.
  * Keyboard shortcuts provide English defaults when localized settings are unavailable.
  * Performance reporting now tracks interaction responsiveness using the current metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->