### PR TITLE
refactor: convert not-found page to TypeScript

### DIFF
--- a/src/pages/not-found/index.tsx
+++ b/src/pages/not-found/index.tsx
@@ -5,7 +5,7 @@ import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
 import logo from "../../assets/404.png";
 
-export default function Insights() {
+export default function NotFound() {
   const { t } = useTranslation();
 
   return (


### PR DESCRIPTION
## Summary

- Convert the not-found page from JSX to TSX.
- Rename the component from `Insights` to `NotFound`.
- Preserve existing routing and presentation.

## Validation

- `yarn lint`
- `yarn build`