### PR TITLE
fix: correct webcomponent asset paths

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,8 +8,9 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: "node_modules/@openfoodfacts/openfoodfacts-webcomponents/dist/assets/**/*",
+          src: "node_modules/@openfoodfacts/openfoodfacts-webcomponents/dist/assets/images/**/*",
           dest: "assets/webcomponents",
+          rename: { stripBase: 6 },
         },
       ],
     }),


### PR DESCRIPTION
## Summary

- Copy webcomponent images from the package’s images directory.
- Strip the package path so appstore assets resolve under `/assets/webcomponents`.
- Prevent repeated failed image retries in the webcomponent.

## Validation

- `yarn lint`
- `yarn build`
- Verified `dist/assets/webcomponents/appstore/black/appstore_UK.svg` exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized asset copying during the build process.
  * Web component images are now placed in a cleaner, more consistent location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->