### PR TITLE
perf: split webcomponent bundle and fix JSX types

### DIFF
--- a/src/components/OffWebcomponents.tsx
+++ b/src/components/OffWebcomponents.tsx
@@ -1,9 +1,24 @@
+import * as React from "react";
 import { OFF_IMAGE_URL, OFF_URL, ROBOTOFF_API_URL } from "../const";
 import { useTranslation } from "react-i18next";
-import "@openfoodfacts/openfoodfacts-webcomponents";
+
+let webcomponentsLoadPromise: Promise<unknown> | undefined;
+
+const loadWebcomponents = () => {
+  webcomponentsLoadPromise ??=
+    import("@openfoodfacts/openfoodfacts-webcomponents");
+  return webcomponentsLoadPromise;
+};
 
 export const OffWebcomponentsConfiguration = () => {
   const { i18n } = useTranslation();
+
+  React.useEffect(() => {
+    void loadWebcomponents().catch((error) => {
+      console.error("Failed to load Open Food Facts webcomponents", error);
+    });
+  }, []);
+
   // Ensure we have a valid 2-letter language code
   const languageCode = i18n.language?.substring(0, 2) || "en";
 

--- a/src/types/off-webcomponents.d.ts
+++ b/src/types/off-webcomponents.d.ts
@@ -1,38 +1,41 @@
-declare namespace JSX {
-  interface IntrinsicElements {
-    "off-webcomponents-configuration": React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement> & {
-        "robotoff-configuration"?: string;
-        "openfoodfacts-api-url"?: string;
-        languageCode?: string;
-      },
-      HTMLElement
-    >;
+declare namespace React {
+  namespace JSX {
+    interface IntrinsicElements {
+      "off-webcomponents-configuration": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          "robotoff-configuration"?: string;
+          "openfoodfacts-api-url"?: string;
+          "language-code"?: string;
+          "assets-images-path"?: string;
+        },
+        HTMLElement
+      >;
 
-    "robotoff-nutrient-extraction": React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement> & {
-        "product-code"?: string;
-        "country-codes"?: string;
-        "language-codes"?: string;
-        "display-product-link"?: boolean;
-      },
-      HTMLElement
-    >;
-    "robotoff-ingredient-spellcheck": React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement>,
-      HTMLElement
-    >;
-    "robotoff-ingredient-detection": React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement>,
-      HTMLElement
-    >;
-    "donation-banner": React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement>,
-      HTMLElement
-    >;
-    "mobile-badges": React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement>,
-      HTMLElement
-    >;
+      "robotoff-nutrient-extraction": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          "product-code"?: string;
+          "country-codes"?: string;
+          "language-codes"?: string;
+          "display-product-link"?: boolean;
+        },
+        HTMLElement
+      >;
+      "robotoff-ingredient-spellcheck": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      "robotoff-ingredient-detection": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      "donation-banner": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      "mobile-badges": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+    }
   }
 }

--- a/src/types/openfoodfacts-webcomponents.d.ts
+++ b/src/types/openfoodfacts-webcomponents.d.ts
@@ -1,0 +1,1 @@
+declare module "@openfoodfacts/openfoodfacts-webcomponents";


### PR DESCRIPTION
## Summary
- Defer the Open Food Facts webcomponent registration so its 480 KB bundle is loaded asynchronously instead of in the entry chunk.
- Reduce the entry chunk from ~938 KB to ~480 KB and remove the Vite chunk-size warning.
- Handle webcomponent load failures and declare custom elements under React.JSX for React 19 TypeScript support.

## Validation
- yarn lint passed.
- yarn build passed with no chunk-size warning.
- Custom-element JSX diagnostics are resolved; remaining TypeScript diagnostics are pre-existing unrelated issues.

## Stack
- This PR targets chore/upgrade-mui-9-latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web components now load on demand, improving initial application loading.
  * Added support for configuring the web components’ language and image asset path.

* **Bug Fixes**
  * Improved compatibility with current React JSX type declarations.
  * Added support for resolving the web components package in TypeScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->