### PR TITLE
build(vite): prefix locale chunks

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -18,4 +18,22 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ["js-big-decimal"],
   },
+  build: {
+    rolldownOptions: {
+      output: {
+        chunkFileNames: (chunkInfo) => {
+          // i18next dynamically imports locale JSON; prefix those chunks without
+          // changing the names of route and vendor chunks.
+          const isLanguageChunk = chunkInfo.moduleIds.some(
+            (moduleId) =>
+              moduleId.includes("/src/i18n/") && moduleId.endsWith(".json"),
+          );
+
+          return isLanguageChunk
+            ? "assets/lang-[name]-[hash].js"
+            : "assets/[name]-[hash].js";
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Prefix dynamically loaded locale chunks with lang- for easier identification.
- Preserve the existing dist/assets output location and route/vendor chunk names.

## Validation
- yarn lint passed.
- yarn build passed.
- Verified all locale JSON modules emit as assets/lang-<locale>-<hash>.js.

## Stack
- This PR targets perf/split-webcomponent-chunk.