### PR TITLE
fix(a11y): translate accessible control labels

### DIFF
--- a/src/components/Footer/OpenFoodFacts.tsx
+++ b/src/components/Footer/OpenFoodFacts.tsx
@@ -8,18 +8,22 @@ import { useTranslation } from "react-i18next";
 const socialMedia = [
   {
     icon: <EmailIcon />,
+    labelKey: "footer.social.email",
     link: "mailto:contact@openfoodfacts.org",
   },
   {
     icon: <TwitterIcon />,
+    labelKey: "footer.social.twitter",
     link: "https://twitter.com/openfoodfacts",
   },
   {
     icon: <InstagramIcon />,
+    labelKey: "footer.social.instagram",
     link: "https://www.instagram.com/open.food.facts/",
   },
   {
     icon: <FacebookIcon />,
+    labelKey: "footer.social.facebook",
     link: "https://www.facebook.com/OpenFoodFacts",
   },
 ];
@@ -61,7 +65,12 @@ export default function OpenFoodFacts() {
       <Box>
         {socialMedia.map((media) => {
           return (
-            <IconButton key={media.link} href={media.link} target="_blank">
+            <IconButton
+              key={media.link}
+              href={media.link}
+              target="_blank"
+              aria-label={t(media.labelKey)}
+            >
               {media.icon}
             </IconButton>
           );

--- a/src/components/ResponsiveAppBar.tsx
+++ b/src/components/ResponsiveAppBar.tsx
@@ -255,7 +255,9 @@ const ResponsiveAppBar = () => {
           >
             <IconButton
               size="large"
-              aria-label="account of current user"
+              aria-label={t("menu.open_navigation", {
+                defaultValue: "Open navigation menu",
+              })}
               aria-controls="menu-appbar"
               aria-haspopup="true"
               onClick={handleOpenNavMenu}
@@ -411,6 +413,7 @@ const ResponsiveAppBar = () => {
               <AccountCircleIcon color="success" />
             ) : (
               <IconButton
+                aria-label={t("menu.log_in")}
                 onClick={() =>
                   void (async () => {
                     const isLoggedIn = await refresh();
@@ -622,6 +625,7 @@ const ResponsiveAppBar = () => {
                 />
               </Box>
               <IconButton
+                aria-label={t("menu.settings")}
                 color="inherit"
                 onClick={handleCloseNavMenu}
                 sx={{ my: 2 }}
@@ -632,6 +636,7 @@ const ResponsiveAppBar = () => {
                 <SettingsIcon />
               </IconButton>
               <IconButton
+                aria-label={t("menu.tour")}
                 color="inherit"
                 onClick={() => {
                   setIsTourOpen(true);
@@ -661,6 +666,7 @@ const ResponsiveAppBar = () => {
                   </Box>
                 ) : (
                   <IconButton
+                    aria-label={t("menu.log_in")}
                     onClick={() =>
                       void (async () => {
                         const isLoggedIn = await refresh();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -168,6 +168,7 @@
     "green-score": "Green score",
     "dashboard": "Logo dashboard",
     "tour": "Take a tour",
+    "open_navigation": "Open navigation menu",
     "logged_in_user": "Logged in as {{userName}}",
     "log_in": "Log in",
     "moderation": "Moderation",
@@ -407,6 +408,12 @@
     "getRobotoffPrediciton": "Get predictions from Robotoff"
   },
   "footer": {
+    "social": {
+      "email": "Email Open Food Facts",
+      "twitter": "Open Food Facts on Twitter",
+      "instagram": "Open Food Facts on Instagram",
+      "facebook": "Open Food Facts on Facebook"
+    },
     "appStore": {
       "title": "App Store",
       "subtitle": "Download on the"

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -162,6 +162,7 @@
     "green-score": "Green-Score",
     "dashboard": "Dashboard dei loghi",
     "tour": "Inizia la visita guidata",
+    "open_navigation": "Apri il menu di navigazione",
     "logged_in_user": "Accesso effettuato come {{userName}}",
     "log_in": "Accedi",
     "moderation": "Moderazione",
@@ -401,6 +402,12 @@
     "getRobotoffPrediciton": "Ottieni previsioni da Robotoff"
   },
   "footer": {
+    "social": {
+      "email": "Email Open Food Facts",
+      "twitter": "Open Food Facts su Twitter",
+      "instagram": "Open Food Facts su Instagram",
+      "facebook": "Open Food Facts su Facebook"
+    },
     "appStore": {
       "title": "App Store",
       "subtitle": "Scarica da"


### PR DESCRIPTION
## Summary

- Add translated accessible names for navbar controls.
- Add localized social-link labels in English and Italian.
- Retain the English fallback for other locales.

## Validation

- `yarn lint`
- `yarn build`
