### PR TITLE
Improve questions page layout

### DIFF
--- a/src/pages/questions/ProductInformation.tsx
+++ b/src/pages/questions/ProductInformation.tsx
@@ -62,17 +62,14 @@ const ProductImagesGrid = ({
       sx={{
         display: "grid",
         width: "100%",
-        gridGap: "30px",
-        gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
+        gap: 1.5,
+        gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
 
         backgroundColor: theme.palette.mode === "dark" ? "#201f1ff5" : "white",
         maxHeight: "32rem",
-        overflowY: "scroll",
-        ml: "1px",
-        mt: "2px",
-        pl: "10px",
-        py: "10px",
-        borderRadius: "10px",
+        overflowY: "auto",
+        p: 1,
+        borderRadius: 2,
         scrollbarWidth: "thin",
         scrollbarColor:
           theme.palette.mode === "dark" ? "#4e4d4dff #201f1f" : "",
@@ -280,7 +277,7 @@ const ProductInformation = () => {
       <>
         {/* Product name or code */}
         <Typography
-          variant="h4"
+          variant="h5"
           gutterBottom
           sx={{
             fontFamily: productData?.product_name ? "inherit" : "monospace",
@@ -333,7 +330,7 @@ const ProductInformation = () => {
 
       {/* Other questions */}
       <>
-        <Typography variant="h5" gutterBottom>
+        <Typography variant="h6" gutterBottom>
           {t("questions.other_questions")}
         </Typography>
         <ProductOtherQuestions question={question} />

--- a/src/pages/questions/ProductOtherQuestions.tsx
+++ b/src/pages/questions/ProductOtherQuestions.tsx
@@ -48,78 +48,82 @@ export default function ProductOtherQuestions({
     return <Typography>No other questions</Typography>;
   }
 
-  return filteredData.map((otherQuestion) => {
-    const insight_id = otherQuestion.insight_id;
-    const pendingAnswer = answers[insight_id]?.value ?? null;
+  return (
+    <Stack spacing={2}>
+      {filteredData.map((otherQuestion) => {
+        const insight_id = otherQuestion.insight_id;
+        const pendingAnswer = answers[insight_id]?.value ?? null;
 
-    // Set the value,n or move it to `null` if already set.
-    const toggleValue = (
-      value: typeof WRONG_INSIGHT | typeof CORRECT_INSIGHT,
-    ) =>
-      setAnswers((prev) => ({
-        ...prev,
-        [insight_id]: {
-          value: prev[insight_id]?.value === value ? null : value,
-          sent: false,
-        },
-      }));
+        // Set the value,n or move it to `null` if already set.
+        const toggleValue = (
+          value: typeof WRONG_INSIGHT | typeof CORRECT_INSIGHT,
+        ) =>
+          setAnswers((prev) => ({
+            ...prev,
+            [insight_id]: {
+              value: prev[insight_id]?.value === value ? null : value,
+              sent: false,
+            },
+          }));
 
-    const valueIsSet =
-      pendingAnswer === CORRECT_INSIGHT || pendingAnswer === WRONG_INSIGHT;
-    const sendAnswer = valueIsSet
-      ? () => {
-          robotoff
-            .annotate(insight_id, pendingAnswer)
-            .then(() => {
-              setAnswers((prev) => ({
-                ...prev,
-                [insight_id]: {
-                  ...prev[insight_id],
-                  sent: true,
-                },
-              }));
-            })
-            .catch(() => {});
-        }
-      : noop;
+        const valueIsSet =
+          pendingAnswer === CORRECT_INSIGHT || pendingAnswer === WRONG_INSIGHT;
+        const sendAnswer = valueIsSet
+          ? () => {
+              robotoff
+                .annotate(insight_id, pendingAnswer)
+                .then(() => {
+                  setAnswers((prev) => ({
+                    ...prev,
+                    [insight_id]: {
+                      ...prev[insight_id],
+                      sent: true,
+                    },
+                  }));
+                })
+                .catch(() => {});
+            }
+          : noop;
 
-    return (
-      <Stack
-        direction="row"
-        key={otherQuestion.insight_id}
-        sx={{ mt: 1, alignItems: "flex-start" }}
-      >
-        <Typography key={otherQuestion.insight_id}>
-          {otherQuestion.question} ({otherQuestion.value})
-        </Typography>
-        <Button
-          onClick={() => toggleValue(CORRECT_INSIGHT)}
-          variant={pendingAnswer === CORRECT_INSIGHT ? "contained" : "outlined"}
-          color="success"
-          size="small"
-          sx={{ ml: 1 }}
-        >
-          {t("questions.yes")}
-        </Button>
-        <Button
-          onClick={() => toggleValue(WRONG_INSIGHT)}
-          variant={pendingAnswer === WRONG_INSIGHT ? "contained" : "outlined"}
-          color="error"
-          size="small"
-        >
-          {t("questions.no")}
-        </Button>
-        <Button
-          onClick={sendAnswer}
-          disabled={!valueIsSet}
-          color="secondary"
-          variant="contained"
-          size="small"
-          sx={{ ml: 1 }}
-        >
-          {t("questions.send")}
-        </Button>
-      </Stack>
-    );
-  });
+        return (
+          <Stack spacing={0.75} key={otherQuestion.insight_id}>
+            <Typography key={otherQuestion.insight_id}>
+              {otherQuestion.question} ({otherQuestion.value})
+            </Typography>
+            <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
+              <Button
+                onClick={() => toggleValue(CORRECT_INSIGHT)}
+                variant={
+                  pendingAnswer === CORRECT_INSIGHT ? "contained" : "outlined"
+                }
+                color="success"
+                size="small"
+              >
+                {t("questions.yes")}
+              </Button>
+              <Button
+                onClick={() => toggleValue(WRONG_INSIGHT)}
+                variant={
+                  pendingAnswer === WRONG_INSIGHT ? "contained" : "outlined"
+                }
+                color="error"
+                size="small"
+              >
+                {t("questions.no")}
+              </Button>
+              <Button
+                onClick={sendAnswer}
+                disabled={!valueIsSet}
+                color="primary"
+                variant="contained"
+                size="small"
+              >
+                {t("questions.send")}
+              </Button>
+            </Stack>
+          </Stack>
+        );
+      })}
+    </Stack>
+  );
 }

--- a/src/pages/questions/QuestionDisplay.tsx
+++ b/src/pages/questions/QuestionDisplay.tsx
@@ -73,23 +73,26 @@ function QuestionAnswerButtons({
   const { t } = useTranslation();
 
   return (
-    <>
-      <Stack
-        direction="row"
-        spacing={2}
-        sx={{
-          justifyContent: "center",
-          mb: 1,
-        }}
-      >
+    <Stack
+      spacing={1.25}
+      sx={{
+        position: "sticky",
+        bottom: 0,
+        zIndex: 10,
+        bgcolor: "background.paper",
+        pt: 1,
+        pb: "max(0px, env(safe-area-inset-bottom))",
+      }}
+    >
+      <Stack direction="row" spacing={1.25}>
         <Button
           onClick={() => onAnswerQuestion(WRONG_INSIGHT)}
           color="error"
           variant="contained"
           size="large"
-          sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}
+          startIcon={<DeleteIcon />}
+          sx={{ flexGrow: 1, minHeight: 52 }}
         >
-          <DeleteIcon />
           {t("questions.no")} ({shortcuts.no})
         </Button>
         <Button
@@ -98,7 +101,7 @@ function QuestionAnswerButtons({
           color="success"
           variant="contained"
           size="large"
-          sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}
+          sx={{ flexGrow: 1, minHeight: 52 }}
         >
           {t("questions.yes")} ({shortcuts.yes})
         </Button>
@@ -109,11 +112,11 @@ function QuestionAnswerButtons({
         variant="contained"
         size="medium"
         autoFocus
-        sx={{ py: "1rem" }}
+        sx={{ py: 1.25 }}
       >
         {t("questions.skip")} ({shortcuts.skip})
       </Button>
-    </>
+    </Stack>
   );
 }
 
@@ -236,11 +239,17 @@ export default function QuestionDisplay() {
 
   return (
     <Stack
-      sx={{ textAlign: "center", flexGrow: 1, flexBasis: 0, flexShrink: 1 }}
+      sx={{
+        textAlign: "center",
+        flexGrow: 1,
+        minHeight: { xs: 560, md: 0 },
+      }}
     >
       {/* Header */}
       <Stack sx={{ alignItems: "center" }}>
-        <Typography>{question?.question}</Typography>
+        <Typography variant="h6" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+          {question?.question}
+        </Typography>
         <Box sx={{ display: "flex", alignItems: "center" }}>
           {valueTagQuestionsURL ? (
             <Badge
@@ -293,9 +302,13 @@ export default function QuestionDisplay() {
         sx={{
           flexGrow: 1,
           flexShrink: 1,
-          height: `calc(100vh - ${isDesktop ? 461 : 445}px)`,
-          marginBottom: 1,
+          minHeight: { xs: 300, sm: 360, md: 280 },
+          height: isDesktop ? "calc(100vh - 440px)" : "min(52vh, 520px)",
+          my: 1.5,
           position: "relative",
+          overflow: "hidden",
+          borderRadius: 2,
+          bgcolor: "action.hover",
         }}
       >
         {question.source_image_url ? (

--- a/src/pages/questions/UserData.tsx
+++ b/src/pages/questions/UserData.tsx
@@ -34,34 +34,41 @@ const UserData = () => {
 
   return (
     <Box>
-      <Stack spacing={1}>
-        <Typography sx={{ my: 2 }}>
+      <Stack spacing={1.25}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
           {t("questions.remaining_annotations")}:{" "}
           {questionsCount !== null && questionsCount >= 99
             ? "100+"
             : (questionsCount ?? 0)}
         </Typography>
-        {recentAnswers.map(
-          ({ insight_id, barcode, value, insight_type, answer }) => (
-            <Stack
-              key={insight_id}
-              direction="row"
-              sx={{
-                alignItems: "center",
-              }}
-            >
-              <Link href={offService.getProductEditUrl(barcode)}>
-                {insight_type}: {value}
-              </Link>
-              {answer === WRONG_INSIGHT && (
-                <CancelOutlinedIcon color="error" sx={{ ml: 2 }} />
-              )}
-              {answer === CORRECT_INSIGHT && (
-                <CheckCircleOutlineIcon color="success" sx={{ ml: 2 }} />
-              )}
-            </Stack>
-          ),
-        )}
+        <Stack spacing={1} sx={{ maxHeight: 160, overflowY: "auto", pr: 0.5 }}>
+          {recentAnswers.map(
+            ({ insight_id, barcode, value, insight_type, answer }) => (
+              <Stack
+                key={insight_id}
+                direction="row"
+                sx={{
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 1,
+                }}
+              >
+                <Link
+                  href={offService.getProductEditUrl(barcode)}
+                  sx={{ overflowWrap: "anywhere", fontSize: "0.875rem" }}
+                >
+                  {insight_type}: {value}
+                </Link>
+                {answer === WRONG_INSIGHT && (
+                  <CancelOutlinedIcon color="error" fontSize="small" />
+                )}
+                {answer === CORRECT_INSIGHT && (
+                  <CheckCircleOutlineIcon color="success" fontSize="small" />
+                )}
+              </Stack>
+            ),
+          )}
+        </Stack>
       </Stack>
       <Dialog
         open={loginModalOpen}

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -6,34 +6,67 @@ import UserData from "./UserData";
 import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
 import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Paper from "@mui/material/Paper";
 
 function QuestionsConsumer() {
   return (
-    <Grid container spacing={2} sx={{ p: 2 }}>
-      <Grid size={{ xs: 12, md: 5 }}>
-        <Stack
-          direction="column"
-          sx={{
-            height: { xs: "calc(100vh - 76px)", md: "calc(100vh - 110px)" },
-          }}
-        >
-          <QuestionFilter sx={{ mb: 1 }} />
-          <Divider sx={{ margin: "1rem" }} />
-          <QuestionDisplay />
-        </Stack>
-      </Grid>
-      <Grid size={{ xs: 12, md: 5 }}>
-        <ProductInformation />
-      </Grid>
-      <Grid size={{ xs: 12, md: 2 }}>
-        <UserData />
-      </Grid>
+    <Box
+      sx={{
+        bgcolor: "action.hover",
+        minHeight: "calc(100vh - 64px)",
+        "& .MuiButton-contained": {
+          boxShadow: "none",
+          "&:hover, &:active": { boxShadow: "none" },
+        },
+      }}
+    >
+      <Container maxWidth="xl" sx={{ py: { xs: 1.5, sm: 2.5 } }}>
+        <Grid container spacing={{ xs: 2, lg: 3 }} alignItems="flex-start">
+          <Grid size={{ xs: 12, md: 7, lg: 8 }}>
+            <Paper
+              variant="outlined"
+              sx={{
+                p: { xs: 1.5, sm: 2 },
+                borderRadius: 3,
+                minHeight: { md: "calc(100vh - 116px)" },
+                height: { md: "calc(100vh - 116px)" },
+                overflow: { md: "hidden" },
+              }}
+            >
+              <Stack
+                direction="column"
+                sx={{ minHeight: "inherit", height: { md: "100%" } }}
+              >
+                <QuestionFilter />
+                <Divider sx={{ my: { xs: 1.5, sm: 2 } }} />
+                <QuestionDisplay />
+              </Stack>
+            </Paper>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 5, lg: 4 }}>
+            <Stack spacing={2}>
+              <Paper
+                variant="outlined"
+                sx={{ p: { xs: 1.5, sm: 2 }, borderRadius: 3 }}
+              >
+                <ProductInformation />
+              </Paper>
+              <Paper variant="outlined" sx={{ p: 2, borderRadius: 3 }}>
+                <UserData />
+              </Paper>
+            </Stack>
+          </Grid>
+        </Grid>
+      </Container>
 
       {/* pre-fetch images of the next question */}
       {/* {nextImages.map((source_image_url) => (
         <link rel="prefetch" key={source_image_url} href={source_image_url} />
       ))} */}
-    </Grid>
+    </Box>
   );
 }
 


### PR DESCRIPTION
## Summary
- reorganize the questions page into a responsive two-column workspace
- keep product information visible and constrain recent-answer history
- keep the primary answer controls accessible without scrolling
- improve spacing and visual hierarchy for question and product actions
- flatten contained-button shadows to match the card-based design

## Testing
- yarn build
- git diff --check