### PR TITLE
fix: remove forced Height and sticky positioning on QuestionAnswerButtons

### DIFF
--- a/src/pages/questions/QuestionDisplay.tsx
+++ b/src/pages/questions/QuestionDisplay.tsx
@@ -76,8 +76,6 @@ function QuestionAnswerButtons({
     <Stack
       spacing={1.25}
       sx={{
-        position: "sticky",
-        bottom: 0,
         zIndex: 10,
         bgcolor: "background.paper",
         pt: 1,

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -31,7 +31,6 @@ function QuestionsConsumer() {
                 p: { xs: 1.5, sm: 2 },
                 borderRadius: 3,
                 minHeight: { md: "calc(100vh - 116px)" },
-                height: { md: "calc(100vh - 116px)" },
                 overflow: { md: "hidden" },
               }}
             >


### PR DESCRIPTION

### What
Remove fixed height from the Paper component in questions/index.tsx to allow internal elements to size and lay out correctly.

Fix sticky positioning and layout handling for QuestionAnswerButtons in QuestionDisplay.tsx to prevent images from being obscured behind the button bar on smaller viewports.

### Screenshot
<img width="908" height="600" alt="image" src="https://github.com/user-attachments/assets/65b4d4a6-2c99-44c4-ba5a-8becc8746af5" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Answer buttons are no longer pinned to the bottom of the viewport, improving interaction while viewing questions.
  * The questions list panel can now expand beyond the viewport height when content requires additional space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->