### PR TITLE
fix(footer): drop the light backdrop behind the app badges

### DIFF
--- a/src/components/Footer/DownloadOpenFoodFacts.jsx
+++ b/src/components/Footer/DownloadOpenFoodFacts.jsx
@@ -1,6 +1,11 @@
-import { Box } from "@mui/material";
+import { Box, useMediaQuery, useTheme } from "@mui/material";
 
 export default function DownloadOpenFoodFacts() {
+  const theme = useTheme();
+  const systemPrefersDark = useMediaQuery("(prefers-color-scheme: dark)");
+  const needsLightBackdrop =
+    theme.palette.mode === "dark" && !systemPrefersDark;
+
   return (
     <Box
       className="OFF-download"
@@ -8,12 +13,10 @@ export default function DownloadOpenFoodFacts() {
     >
       <Box
         sx={{
-          // light panel so the badge's black text stays readable in dark mode
-          bgcolor: (theme) =>
-            theme.palette.mode === "dark" ? "#f5f5f5" : "transparent",
-          borderRadius: "16px",
-          px: 3,
-          py: 2,
+          bgcolor: needsLightBackdrop ? "#f5f5f5" : "transparent",
+          borderRadius: needsLightBackdrop ? "16px" : 0,
+          px: needsLightBackdrop ? 3 : 0,
+          py: needsLightBackdrop ? 2 : 0,
           display: "inline-flex",
         }}
       >


### PR DESCRIPTION
### It wasn't the web component

You wondered whether this was already fixed upstream. It isn't an upstream bug — the white line comes from our own code, and I added it, in #1534. Sorry about that.

`DownloadOpenFoodFacts.jsx` painted a light `#f5f5f5` panel behind the banner in dark mode, with padding around it. The padding is the pale border in your screenshot.

For what it's worth, `1.16.0` is already the latest published version of openfoodfacts-webcomponents, so there's no update to pick up here.

### Why the panel was there

`mobile-badges` styles itself for dark mode — it sets its own `background-color: #201a17` and light text. So the backdrop is redundant most of the time.

But it decides that from **`window.matchMedia("(prefers-color-scheme: dark)")`**, the operating system setting — not from our own light/dark toggle. So when someone's system is light but they've switched Hunger Games to dark, the banner renders in its light style inside a dark page and the text becomes hard to read. That's the case the panel was covering.

### The fix

The backdrop now applies only when those two actually disagree:

```js
const needsLightBackdrop = theme.palette.mode === "dark" && !systemPrefersDark;
```

- System dark + app dark → no backdrop, component's own dark styling shows, **white line gone**
- System light + app dark → backdrop kept, badges stay readable
- App in light mode → unchanged

Your screenshot is the first case, so the border should be gone for you.

### Worth doing upstream

The real fix is for `mobile-badges` to accept a dark-mode override so a host app can tell it which theme it's using, instead of it reading the OS directly. Then this workaround could go away entirely. Happy to open an issue on openfoodfacts-webcomponents for that if you think it's worth it.

### Verification

- `prettier --check` — clean
- `eslint` — no findings in this file
- `tsc --noEmit` — clean
- `yarn build` — passes

Fixes #1668


<img width="1433" height="193" alt="Screenshot 2026-09-07 at 4 22 18 PM" src="https://github.com/user-attachments/assets/a8525400-f6a9-4c09-9c4a-e239cae58fde" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the download badge’s appearance for dark themes when the system uses a light color scheme.
  - Added a light backdrop, rounded corners, and spacing in this scenario.
  - Preserved the transparent, unpadded appearance when dark mode is preferred by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->