### PR TITLE
fix(questions): read dev mode from context on the question page

### DIFF
--- a/src/pages/questions/ProductInformation.tsx
+++ b/src/pages/questions/ProductInformation.tsx
@@ -33,8 +33,8 @@ import {
   localSettingsKeys,
   getHideImages,
   getPageCustomization,
-  getIsDevMode,
 } from "../../localeStorageManager";
+import DevModeContext from "../../contexts/devMode";
 
 import {
   ADDITIONAL_INFO_TRANSLATION,
@@ -246,7 +246,7 @@ const ProductInfoTable = ({
 
 const ProductInformation = () => {
   const { t } = useTranslation();
-  const isDevMode = getIsDevMode();
+  const { devMode: isDevMode } = React.useContext(DevModeContext);
 
   // Hide images
   const [hideImages, setHideImages] = React.useState<boolean>(getHideImages);


### PR DESCRIPTION
### These are already behind dev mode

The `resume` and `raw JSON` accordions come from `DebugQuestion`, and `ProductInformation` only renders it when dev mode is on:

```jsx
{isDevMode && devCustomization.showDebug && (
  <DebugQuestion insightId={question.insight_id} />
)}
```

That gate was added back in March (`ca898862`), the toggle already exists in Settings, and `getIsDevMode()` defaults to `false`. So a normal visitor never sees them — you're most likely seeing them because you have dev mode switched on in your own browser.

Worth checking on your side before this goes any further, in case you were expecting something different.

### One real problem I did find

The question page was the **only** place in the app reading the setting straight from local storage:

```js
const isDevMode = getIsDevMode();
```

Everywhere else — the app bar, the settings page — uses `DevModeContext`. Reading local storage directly gives a value captured when the component mounts, so flipping the toggle in Settings didn't affect an already-mounted question page. That may well be what made it look like the accordions weren't behind the toggle at all.

This PR switches that one line to the context, so the toggle takes effect immediately and the question page behaves like the rest of the app.

### If you wanted something else

If the intent was to hide them from dev mode users too, or to give them their own switch separate from dev mode, say the word and I'll rework it — that would be a different change from this one.

### Verification

- `prettier --check` — clean
- `eslint` — 0 findings, same as master
- `tsc --noEmit` — clean
- `yarn build` — passes

Refs #1666


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated development-mode detection to use the application’s shared context, with no expected change to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->