### PR TITLE
fix(home): load each user statistic independently

### DIFF
--- a/src/pages/home/UserData.tsx
+++ b/src/pages/home/UserData.tsx
@@ -6,64 +6,70 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
+import Skeleton from "@mui/material/Skeleton";
 import CardActionArea from "@mui/material/CardActionArea";
 import EditIcon from "@mui/icons-material/Edit";
 import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
 import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
-import { CircularProgress, SvgIconProps } from "@mui/material";
+import { SvgIconProps } from "@mui/material";
 
 import { offClient } from "../../off";
 import { OFF_URL } from "../../const";
 import { useQuery } from "@tanstack/react-query";
 
-type CountCardProps = {
+type StatDetail = {
   translationKey: string;
-  value: number | null | undefined;
+  apiFacet: string;
+  linkFacet: string;
   Icon: React.ComponentType<SvgIconProps>;
-  href?: string;
 };
 
-const STAT_DETAILS: Record<
-  string,
-  { facet: string; Icon: React.ComponentType<SvgIconProps> }
-> = {
-  contributorCount: { facet: "contributors", Icon: AddAPhotoIcon },
-  editorCount: { facet: "editors", Icon: EditIcon },
-  photographerCount: { facet: "photographers", Icon: PhotoCameraIcon },
+type CountCardProps = StatDetail & {
+  userName: string;
 };
 
 type UserDataProps = {
   userName: string;
 };
 
-const fetchUserData = async (userName: string) => {
-  const editorPromise = offClient
-    .getFacetValue("editor", userName, {})
-    .then((value) => value.count)
-    .catch(() => undefined);
-
-  const contributorPromise = offClient
-    .getFacetValue("contributor", userName, {})
-    .then((value) => value.count)
-    .catch(() => undefined);
-  const photographerPromise = offClient
-    .getFacetValue("photographer", userName, {})
-    .then((value) => value.count)
-    .catch(() => undefined);
-
-  const [editorCount, contributorCount, photographerCount] = await Promise.all([
-    editorPromise,
-    contributorPromise,
-    photographerPromise,
-  ]);
-
-  return { editorCount, contributorCount, photographerCount };
-};
+const STATS: StatDetail[] = [
+  {
+    translationKey: "editorCount",
+    apiFacet: "editor",
+    linkFacet: "editors",
+    Icon: EditIcon,
+  },
+  {
+    translationKey: "contributorCount",
+    apiFacet: "contributor",
+    linkFacet: "contributors",
+    Icon: AddAPhotoIcon,
+  },
+  {
+    translationKey: "photographerCount",
+    apiFacet: "photographer",
+    linkFacet: "photographers",
+    Icon: PhotoCameraIcon,
+  },
+];
 
 const CountCard = (props: CountCardProps) => {
-  const { translationKey, value, Icon, href } = props;
+  const { translationKey, apiFacet, linkFacet, Icon, userName } = props;
 
   const { t } = useTranslation();
+
+  const { data: value, isPending } = useQuery({
+    queryKey: ["userStat", apiFacet, userName],
+    queryFn: () =>
+      offClient
+        .getFacetValue(apiFacet, userName, {})
+        .then((response) => response.count)
+        .catch(() => undefined),
+  });
+
+  const href = userName
+    ? `${OFF_URL}/facets/${linkFacet}/${encodeURIComponent(userName)}`
+    : undefined;
 
   const content = (
     <CardContent>
@@ -88,15 +94,19 @@ const CountCard = (props: CountCardProps) => {
       >
         {t(`home.statistics.${translationKey}.description`)}
       </Typography>
-      <Typography
-        variant="h3"
-        component="div"
-        sx={{
-          color: "text.primary",
-        }}
-      >
-        {typeof value === "number" ? value.toLocaleString() : "N/A"}
-      </Typography>
+      {isPending ? (
+        <Skeleton variant="text" width="60%" sx={{ fontSize: "3rem" }} />
+      ) : (
+        <Typography
+          variant="h3"
+          component="div"
+          sx={{
+            color: "text.primary",
+          }}
+        >
+          {typeof value === "number" ? value.toLocaleString() : "N/A"}
+        </Typography>
+      )}
     </CardContent>
   );
 
@@ -121,13 +131,6 @@ const CountCard = (props: CountCardProps) => {
 
 const UserData = ({ userName }: UserDataProps) => {
   const { t } = useTranslation();
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["userStats", userName],
-    queryFn: async () => {
-      const data = await fetchUserData(userName);
-      return data;
-    },
-  });
 
   return (
     <Box sx={{ p: 2, mb: 10 }}>
@@ -135,38 +138,11 @@ const UserData = ({ userName }: UserDataProps) => {
         {t("home.statistics.title", { userName: userName || "<unknown>" })}
       </Typography>
 
-      {isLoading ? (
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
-          <CircularProgress />
-        </Box>
-      ) : error ? (
-        <Typography color="error">{error.message}</Typography>
-      ) : (
-        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-          {Object.entries(data ?? {}).map(([countType, value]) => {
-            const details = STAT_DETAILS[countType];
-            return (
-              <CountCard
-                key={countType}
-                translationKey={countType}
-                value={value}
-                Icon={details.Icon}
-                href={
-                  userName
-                    ? `${OFF_URL}/facets/${details.facet}/${encodeURIComponent(userName)}`
-                    : undefined
-                }
-              />
-            );
-          })}
-        </Stack>
-      )}
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+        {STATS.map((stat) => (
+          <CountCard key={stat.translationKey} {...stat} userName={userName} />
+        ))}
+      </Stack>
     </Box>
   );
 };


### PR DESCRIPTION
Does what you suggested — three shims, one per stat, instead of one spinner over the whole block.

### What changed

The three counts were fetched together in a single query with `Promise.all`, and the whole section showed one `CircularProgress` until every request had finished. So the block was always as slow as the slowest of the three.

Each card now runs its own query and shows a skeleton where its number goes. The cards, their titles and their descriptions render immediately, and each number fills in as its own response arrives.

It also ends up simpler — 41 lines added, 65 removed.

### Small behaviour change worth flagging

The old code had a section-level error message if the combined query failed. Each request already had its own `.catch` that produced **N/A**, so that outer error only really fired on an unexpected failure.

Now a failing request just shows **N/A** in its own card and the other two are unaffected. That felt right for three independent numbers — one facet being down shouldn't blank the whole section. Happy to add per-card error text instead if you'd prefer something more explicit.

### Note on #1662

That PR touches this same component to add the icons and product links. The two changes are complementary but will conflict on merge since they both restructure the card. Whichever goes in first, I'll rebase the other — no preference on the order.

### Verification

- `prettier --check` — clean
- `eslint` — 0 findings, same as master
- `tsc --noEmit` — clean
- `yarn build` — passes

Refs #1665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statistic cards now load independently, allowing available counts to appear without waiting for all data.
  * Individual cards display their own loading indicators while results are being retrieved.

* **Bug Fixes**
  * Improved resilience when loading statistics so an issue with one card does not block the others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->