### PR TITLE
feat(home): promote product creation on Open Prices

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -14,6 +14,10 @@
         "green_score": {
           "title": "Green-score",
           "description": "Annotate the questions with the highest value"
+        },
+        "create_products": {
+          "title": "Create missing products",
+          "description": "Add products that are not in the database yet, over on Open Prices"
         }
       }
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -14,6 +14,10 @@
         "green_score": {
           "title": "Green-score",
           "description": "Annotate the questions with the highest value"
+        },
+        "create_products": {
+          "title": "Create missing products",
+          "description": "Add products that are not in the database yet, over on Open Prices"
         }
       }
     },

--- a/src/pages/home/homeCards.jsx
+++ b/src/pages/home/homeCards.jsx
@@ -70,10 +70,12 @@ const HomeCards = () => {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
+                  backgroundColor: "#f6f3f0",
+                  borderRadius: "8px",
                 }}
               >
                 <cardInfo.Icon
-                  sx={{ fontSize: 96, color: "text.secondary" }}
+                  sx={{ fontSize: 96, color: "#85746c" }}
                   aria-hidden
                 />
               </Box>

--- a/src/pages/home/homeCards.jsx
+++ b/src/pages/home/homeCards.jsx
@@ -71,7 +71,7 @@ const HomeCards = () => {
                   alignItems: "center",
                   justifyContent: "center",
                   backgroundColor: "#f6f3f0",
-                  borderRadius: "8px",
+                  borderRadius: "16px",
                 }}
               >
                 <cardInfo.Icon

--- a/src/pages/home/homeCards.jsx
+++ b/src/pages/home/homeCards.jsx
@@ -6,6 +6,8 @@ import CardContent from "@mui/material/CardContent";
 import CardActionArea from "@mui/material/CardActionArea";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import AddShoppingCartIcon from "@mui/icons-material/AddShoppingCart";
 import home_questions from "../../assets/home_questions.svg";
 import home_logos from "../../assets/home_logos.svg";
 
@@ -29,6 +31,12 @@ const cards = [
     image:
       "https://static.openfoodfacts.org/images/attributes/dist/green-score-a.svg",
   },
+  {
+    title: "home.game_selector.cards.create_products.title",
+    desc: "home.game_selector.cards.create_products.description",
+    href: "https://prices.openfoodfacts.org/experiments/create-off-product",
+    Icon: AddShoppingCartIcon,
+  },
 ];
 
 const HomeCards = () => {
@@ -45,14 +53,39 @@ const HomeCards = () => {
     >
       {cards.map((cardInfo) => (
         <Card sx={{ width: 350, height: 300 }} key={cardInfo.title}>
-          <CardActionArea component={Link} to={cardInfo.link}>
-            <CardMedia
-              component="img"
-              height="200"
-              image={cardInfo.image}
-              alt={t(cardInfo.title)}
-              sx={{ objectFit: "contain" }}
-            />
+          <CardActionArea
+            {...(cardInfo.href
+              ? {
+                  component: "a",
+                  href: cardInfo.href,
+                  target: "_blank",
+                  rel: "noreferrer",
+                }
+              : { component: Link, to: cardInfo.link })}
+          >
+            {cardInfo.Icon ? (
+              <Box
+                sx={{
+                  height: 200,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <cardInfo.Icon
+                  sx={{ fontSize: 96, color: "text.secondary" }}
+                  aria-hidden
+                />
+              </Box>
+            ) : (
+              <CardMedia
+                component="img"
+                height="200"
+                image={cardInfo.image}
+                alt={t(cardInfo.title)}
+                sx={{ objectFit: "contain" }}
+              />
+            )}
             <CardContent>
               <Typography variant="h5" component="div">
                 {t(cardInfo.title)}


### PR DESCRIPTION
Adds a fourth card to the home selector pointing at the Open Prices create-off-product experiment.

I know this is marked as needing agreement and a mockup first — I've built it as something concrete to react to rather than a finished proposal. Happy to change or close it.

### What's here

- A **Create missing products** card next to Questions, Logos and Green-Score
- Links to https://prices.openfoodfacts.org/experiments/create-off-product, opening in a new tab
- Existing cards are untouched; the card definition just gained an optional `href`, and external ones render as a link instead of a router route

The reasoning for the placement: someone who has run out of questions to answer is exactly the person who might go and add the products that are missing altogether. The game selector is where they're already looking.

### The image is a placeholder

This is the part that most needs your input. Open Prices doesn't publish a logo I could use — I checked, and there's only a `favicon.ico`, which is far too small for a 200px card. So the card currently shows an MUI shopping-cart icon.

If there's a proper Open Prices asset somewhere, point me at it and I'll swap it in. Otherwise this could use an illustration in the same style as the new Questions and Logos SVGs.

### Wording

Also placeholder, and easy to change — it's two new translation keys:

- **Create missing products**
- *Add products that are not in the database yet, over on Open Prices*

### Verification

- Target URL returns 200
- `prettier --check` — clean
- `eslint` — no findings
- `yarn build` — passes
- Keys added to both `common.json` and `en.json`

Refs #1671
