### PR TITLE
refactor(home): lay the game cards out in a responsive grid

### DIFF
--- a/src/pages/home/homeCards.jsx
+++ b/src/pages/home/homeCards.jsx
@@ -5,7 +5,6 @@ import CardMedia from "@mui/material/CardMedia";
 import CardContent from "@mui/material/CardContent";
 import CardActionArea from "@mui/material/CardActionArea";
 import Typography from "@mui/material/Typography";
-import Stack from "@mui/material/Stack";
 import Box from "@mui/material/Box";
 import AddShoppingCartIcon from "@mui/icons-material/AddShoppingCart";
 import home_questions from "../../assets/home_questions.svg";
@@ -42,17 +41,19 @@ const cards = [
 const HomeCards = () => {
   const { t } = useTranslation();
   return (
-    <Stack
-      spacing={3}
-      direction={{ xs: "column", sm: "column", md: "row" }}
+    <Box
       sx={{
-        alignItems: "center",
-        justifyContent: "center",
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+        gap: 3,
+        maxWidth: 1500,
+        mx: "auto",
+        px: 2,
         marginBottom: "30px",
       }}
     >
       {cards.map((cardInfo) => (
-        <Card sx={{ width: 350, height: 300 }} key={cardInfo.title}>
+        <Card sx={{ width: "100%", height: 300 }} key={cardInfo.title}>
           <CardActionArea
             {...(cardInfo.href
               ? {
@@ -106,7 +107,7 @@ const HomeCards = () => {
           </CardActionArea>
         </Card>
       ))}
-    </Stack>
+    </Box>
   );
 };
 


### PR DESCRIPTION
A fixed row of 350px cards stops working once there are more than three or four. A grid reflows from one column on a phone to as many as fit on a wide screen, which is what the tiles planned in #1678 need.

Refs #1678

### What
- <!-- Describe the Pull Request here -->

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
- <!-- #1, #2 and #3 (change by appropriate issues) -->

### Part of 
- <!-- #1, please use the most granular issue possible -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the home card layout to use a responsive grid.
  * Improved card sizing and spacing across screen widths.
  * Centered the card section within a wider container for a more balanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->