### PR TITLE
feat: redesign home page experience

### DIFF
--- a/src/components/Footer/DiscoverTheProject.tsx
+++ b/src/components/Footer/DiscoverTheProject.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Chip, Divider, Typography } from "@mui/material";
+import { Box, Chip, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 const discover = [
@@ -43,37 +43,40 @@ const discover = [
 export default function DiscoverTheProject() {
   const { t } = useTranslation();
   return (
-    <Box sx={{ width: { xs: "100%", sm: "50%" } }} className="OFF-discover">
-      <Divider
-        sx={{
-          opacity: "0.6",
-        }}
-      >
-        <Chip label="Discover the project" />
-      </Divider>
-      <br />
+    <Box component="section" sx={{ height: "100%" }}>
+      <Typography component="h2" variant="h6" sx={{ mb: 2, fontWeight: 700 }}>
+        {t("settings.discover_the_project")}
+      </Typography>
       <Box
         sx={{
           display: "flex",
           flexWrap: "wrap",
-          gap: "20px",
-          justifyContent: "center",
+          gap: 1,
         }}
       >
         {discover.map((content) => {
           return (
-            <Button
+            <Chip
               key={content.text}
-              sx={{
-                backgroundColor: "#a08d84",
-                "&:hover": { backgroundColor: "#887369" },
-              }}
-              variant="contained"
+              label={t(content.text)}
+              component="a"
               href={content.url}
               target="_blank"
-            >
-              <Typography noWrap>{t(content.text)}</Typography>
-            </Button>
+              rel="noreferrer"
+              clickable
+              variant="outlined"
+              sx={{
+                maxWidth: "100%",
+                height: "auto",
+                borderRadius: 2,
+                py: 0.75,
+                "& .MuiChip-label": {
+                  display: "block",
+                  whiteSpace: "normal",
+                  py: 0.25,
+                },
+              }}
+            />
           );
         })}
       </Box>

--- a/src/components/Footer/Donate.tsx
+++ b/src/components/Footer/Donate.tsx
@@ -1,8 +1,17 @@
+import Box from "@mui/material/Box";
+
 const Donate = () => {
   return (
-    <div className="OFF-donate">
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        minHeight: 56,
+        alignItems: "center",
+      }}
+    >
       <donation-banner></donation-banner>
-    </div>
+    </Box>
   );
 };
 

--- a/src/components/Footer/DownloadOpenFoodFacts.jsx
+++ b/src/components/Footer/DownloadOpenFoodFacts.jsx
@@ -8,8 +8,12 @@ export default function DownloadOpenFoodFacts() {
 
   return (
     <Box
-      className="OFF-download"
-      sx={{ display: "flex", justifyContent: "center" }}
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        minHeight: 56,
+        alignItems: "center",
+      }}
     >
       <Box
         sx={{

--- a/src/components/Footer/JoinTheCommunity.jsx
+++ b/src/components/Footer/JoinTheCommunity.jsx
@@ -1,5 +1,4 @@
-import { Box, Chip, Divider, Step, StepLabel, Stepper } from "@mui/material";
-import Link from "@mui/material/Link";
+import { Box, Link, Stack, Typography } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { useTranslation } from "react-i18next";
 
@@ -26,47 +25,38 @@ const content = [
   },
 ];
 
-function CustomStepIcon() {
-  return (
-    <div>
-      <CheckCircleIcon sx={{ color: "#a08d84" }} />
-    </div>
-  );
-}
-
 export default function JoinTheCommunity() {
   const { t } = useTranslation();
 
   return (
-    <div style={{ flexGrow: "1" }} className="OFF-join">
-      <Divider
-        sx={{
-          opacity: "0.6",
-        }}
+    <Box component="section" sx={{ height: "100%" }}>
+      <Typography component="h2" variant="h6" sx={{ mb: 2, fontWeight: 700 }}>
+        {t("settings.join_community")}
+      </Typography>
+      <Stack
+        component="ul"
+        spacing={1.5}
+        sx={{ m: 0, p: 0, listStyle: "none" }}
       >
-        <Chip label={t("settings.join_community")} />
-      </Divider>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <Stepper orientation="vertical">
-          {content.map((step, index) => (
-            <Step active key={index}>
-              <StepLabel StepIconComponent={CustomStepIcon}>
-                {t(step.tag) + " "}
-
-                <Link href={step.url} underline="always">
-                  {t(step.urlText)}
-                </Link>
-              </StepLabel>
-            </Step>
-          ))}
-        </Stepper>
-      </Box>
-    </div>
+        {content.map((step, index) => (
+          <Box
+            component="li"
+            key={`${step.url}-${index}`}
+            sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}
+          >
+            <CheckCircleIcon
+              sx={{ mt: 0.25, color: "primary.main", fontSize: 20 }}
+              aria-hidden
+            />
+            <Typography component="span" variant="body2">
+              {step.tag ? `${t(step.tag)} ` : ""}
+              <Link href={step.url} target="_blank" rel="noreferrer">
+                {t(step.urlText)}
+              </Link>
+            </Typography>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
   );
 }

--- a/src/components/Footer/OpenFoodFacts.tsx
+++ b/src/components/Footer/OpenFoodFacts.tsx
@@ -1,9 +1,10 @@
-import { Box, Button, IconButton, Typography } from "@mui/material";
+import { Box, Container, IconButton, Stack, Typography } from "@mui/material";
 import EmailIcon from "@mui/icons-material/Email";
 import TwitterIcon from "@mui/icons-material/Twitter";
 import InstagramIcon from "@mui/icons-material/Instagram";
 import FacebookIcon from "@mui/icons-material/Facebook";
 import { useTranslation } from "react-i18next";
+import logo from "../../assets/logo.png";
 
 const socialMedia = [
   {
@@ -35,47 +36,55 @@ export default function OpenFoodFacts() {
       sx={(theme) => ({
         backgroundColor: theme.palette.cafeCreme.main,
         color: theme.palette.cafeCreme.contrastText,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        pb: "20px",
+        borderTop: `1px solid ${theme.palette.divider}`,
       })}
-      className="OFF-social-media"
     >
-      <Button
-        sx={{ cursor: "pointer" }}
-        href="https://world.openfoodfacts.org/"
-        target="_blank"
-      >
-        <img
-          width={"100px"}
-          height={"100px"}
-          src="/logo192.png"
-          alt="openFoodFacts"
-        />
-      </Button>
-      <Typography
-        variant="caption"
-        sx={{
-          textAlign: "center",
-        }}
-      >
-        {t("settings.text2")}
-      </Typography>
-      <Box>
-        {socialMedia.map((media) => {
-          return (
-            <IconButton
-              key={media.link}
-              href={media.link}
-              target="_blank"
-              aria-label={t(media.labelKey)}
-            >
-              {media.icon}
-            </IconButton>
-          );
-        })}
-      </Box>
+      <Container maxWidth="lg" sx={{ py: { xs: 3, sm: 4 } }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2.5}
+          sx={{ alignItems: { xs: "center", sm: "center" } }}
+        >
+          <Box
+            component="a"
+            href="https://world.openfoodfacts.org/"
+            target="_blank"
+            rel="noreferrer"
+            sx={{ display: "flex", flexShrink: 0 }}
+          >
+            <Box
+              component="img"
+              src={logo}
+              alt="Open Food Facts"
+              sx={{ width: 64, height: 64, objectFit: "contain" }}
+            />
+          </Box>
+          <Box sx={{ flex: 1, textAlign: { xs: "center", sm: "left" } }}>
+            <Typography component="h2" variant="h6" sx={{ fontWeight: 800 }}>
+              Open Food Facts
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 0.5, opacity: 0.8 }}>
+              {t("settings.text2")}
+            </Typography>
+          </Box>
+          <Stack direction="row" sx={{ flexShrink: 0 }}>
+            {socialMedia.map((media) => {
+              return (
+                <IconButton
+                  key={media.link}
+                  href={media.link}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={t(media.labelKey)}
+                  color="inherit"
+                >
+                  {media.icon}
+                </IconButton>
+              );
+            })}
+          </Stack>
+        </Stack>
+      </Container>
     </Box>
   );
 }

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,4 +1,6 @@
 import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Paper from "@mui/material/Paper";
 import Donate from "./Donate";
 import JoinTheCommunity from "./JoinTheCommunity";
 import DiscoverTheProject from "./DiscoverTheProject";
@@ -8,34 +10,61 @@ import DownloadOpenFoodFacts from "./DownloadOpenFoodFacts";
 export default function FooterWithLinks() {
   return (
     <Box
-      sx={{
-        "& .OFF-donate,& .OFF-download": {
-          py: 2,
-        },
-        "& .OFF-discover-group": {
-          py: 4,
-        },
-      }}
+      component="footer"
+      sx={(theme) => ({
+        backgroundColor: theme.palette.background.default,
+        borderTop: `1px solid ${theme.palette.divider}`,
+      })}
     >
-      {/* Donate to open food facts */}
-      <Donate />
-      {/*App download links for different platforms*/}
-      <DownloadOpenFoodFacts />
+      <Container maxWidth="lg" sx={{ py: { xs: 3, sm: 5 } }}>
+        <Box sx={{ display: "grid", gap: 2.5 }}>
+          <Paper
+            variant="outlined"
+            sx={{ p: { xs: 1.5, sm: 2.5 }, borderRadius: 3 }}
+          >
+            <Donate />
+          </Paper>
+          <Paper
+            variant="outlined"
+            sx={{ p: { xs: 1.5, sm: 2.5 }, borderRadius: 3 }}
+          >
+            <DownloadOpenFoodFacts />
+          </Paper>
+        </Box>
+      </Container>
       <Box
-        sx={{
-          mx: 2,
-          display: "flex",
-          flexDirection: { xs: "column", sm: "row" },
-          gap: { xs: "10px", sm: "" },
-        }}
-        className="OFF-discover-group"
+        sx={(theme) => ({
+          backgroundColor: theme.palette.action.hover,
+          borderTop: `1px solid ${theme.palette.divider}`,
+          borderBottom: `1px solid ${theme.palette.divider}`,
+        })}
       >
-        {/* Different community platform links */}
-        <JoinTheCommunity />
-        {/* Links for project details */}
-        <DiscoverTheProject />
+        <Container maxWidth="lg" sx={{ py: { xs: 3, sm: 4 } }}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: {
+                xs: "1fr",
+                md: "repeat(2, minmax(0, 1fr))",
+              },
+              gap: 2.5,
+            }}
+          >
+            <Paper
+              variant="outlined"
+              sx={{ p: { xs: 2, sm: 3 }, borderRadius: 3 }}
+            >
+              <JoinTheCommunity />
+            </Paper>
+            <Paper
+              variant="outlined"
+              sx={{ p: { xs: 2, sm: 3 }, borderRadius: 3 }}
+            >
+              <DiscoverTheProject />
+            </Paper>
+          </Box>
+        </Container>
       </Box>
-      {/* Footer with OFF logo and social links */}
       <OpenFoodFacts />
     </Box>
   );

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -8,7 +8,6 @@ import CardMedia from "@mui/material/CardMedia";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import Badge from "@mui/material/Badge";
-import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import Chip from "@mui/material/Chip";
 import TextField from "@mui/material/TextField";
@@ -17,11 +16,14 @@ import IconButton from "@mui/material/IconButton";
 import EditIcon from "@mui/icons-material/Edit";
 import DoneIcon from "@mui/icons-material/Done";
 import ClearIcon from "@mui/icons-material/Clear";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
 
 import robotoff from "../robotoff";
 import { localFavorites } from "../localeStorageManager";
 import logo from "../assets/logo.png";
 import { getQuestionSearchParams } from "./QuestionFilter";
+import { Link as RouterLink } from "react-router";
 
 type FilterState = {
   insightType?: string;
@@ -67,20 +69,28 @@ function EditableCardTitle({
     setIsEditMode(true);
   };
 
-  const handleSave = () => {
+  const handleSave = (event?: React.SyntheticEvent) => {
+    event?.preventDefault();
+    event?.stopPropagation();
     onSave(innerTitle);
     setIsEditMode(false);
   };
 
-  const handleCancel = () => {
+  const handleCancel = (event?: React.SyntheticEvent) => {
+    event?.preventDefault();
+    event?.stopPropagation();
     setInnerTitle(title);
     setIsEditMode(false);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
       handleSave();
     } else if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
       handleCancel();
     }
   };
@@ -223,6 +233,28 @@ type QuestionCardProps = {
   title: string;
   showFilterResume?: boolean;
   editableTitle?: boolean;
+  compact?: boolean;
+  onDelete?: () => void;
+};
+
+const getQuestionCountColor = (
+  count: number | null,
+): "info" | "error" | "success" => {
+  if (count === null) return "info";
+  return count > 0 ? "error" : "success";
+};
+
+const getQuestionCountLabel = (
+  count: number | null,
+  t: ReturnType<typeof useTranslation>["t"],
+) => {
+  if (count === null) {
+    return t("home.saved_filters_pending_unknown");
+  }
+
+  return t("home.saved_filters_pending", {
+    count: count > 99 ? "99+" : count,
+  });
 };
 
 export default function QuestionCard({
@@ -231,13 +263,86 @@ export default function QuestionCard({
   title,
   showFilterResume = false,
   editableTitle = false,
+  compact = false,
+  onDelete,
 }: QuestionCardProps) {
+  const { t } = useTranslation();
   const { data: questionCount } = useQuestionCount(filterState);
   const targetUrl = `/questions?${getQuestionSearchParams(filterState)}`;
 
   const handleTitleSave = (newTitle: string) => {
-    localFavorites.addQuestion(filterState, imageSrc, newTitle);
+    localFavorites.addQuestion(filterState, imageSrc ?? "", newTitle);
   };
+
+  if (compact) {
+    return (
+      <Card
+        sx={(theme) => ({
+          width: "100%",
+          borderRadius: 2,
+          border: `1px solid ${theme.palette.divider}`,
+          boxShadow: "none",
+        })}
+      >
+        <Box sx={{ display: "flex", alignItems: "stretch" }}>
+          <CardActionArea
+            component={RouterLink as React.ElementType}
+            to={targetUrl}
+            sx={{ height: "100%", minWidth: 0, flex: 1 }}
+          >
+            <CardContent sx={{ p: { xs: 1.5, sm: 2 } }}>
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={{ xs: 1, sm: 2 }}
+                sx={{ alignItems: { xs: "stretch", sm: "center" } }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <EditableCardTitle
+                    title={title}
+                    editable={editableTitle}
+                    onSave={handleTitleSave}
+                  />
+                  {showFilterResume && (
+                    <FilterSummaryChips filterState={filterState} />
+                  )}
+                </Box>
+                <Chip
+                  label={getQuestionCountLabel(questionCount ?? null, t)}
+                  color={getQuestionCountColor(questionCount ?? null)}
+                  size="small"
+                  sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}
+                />
+                <ChevronRightRoundedIcon
+                  sx={{
+                    display: { xs: "none", sm: "block" },
+                    color: "action.active",
+                  }}
+                  aria-hidden
+                />
+              </Stack>
+            </CardContent>
+          </CardActionArea>
+          {onDelete && (
+            <IconButton
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onDelete();
+              }}
+              aria-label={t("home.saved_filters_delete")}
+              title={t("home.saved_filters_delete")}
+              sx={{
+                m: 1,
+                alignSelf: { xs: "flex-start", sm: "center" },
+              }}
+            >
+              <DeleteOutlineRoundedIcon />
+            </IconButton>
+          )}
+        </Box>
+      </Card>
+    );
+  }
 
   return (
     <QuestionCountBadge count={questionCount ?? null}>
@@ -249,7 +354,10 @@ export default function QuestionCard({
             onSave={handleTitleSave}
           />
         </CardContent>
-        <CardActionArea component={Link} href={targetUrl}>
+        <CardActionArea
+          component={RouterLink as React.ElementType}
+          to={targetUrl}
+        >
           <CardMedia
             component="img"
             height="200"

--- a/src/components/ResponsiveAppBar.tsx
+++ b/src/components/ResponsiveAppBar.tsx
@@ -102,6 +102,116 @@ const PAGES: Page[] = [
   },
 ];
 
+type NavBrandProps = {
+  externalLogo?: boolean;
+  compact?: boolean;
+};
+
+const NavBrand = ({ externalLogo = false, compact = false }: NavBrandProps) => {
+  const { t } = useTranslation();
+
+  const logoMark = (
+    <Box
+      sx={{
+        width: compact ? 32 : 36,
+        height: compact ? 32 : 36,
+        display: "grid",
+        placeItems: "center",
+        flexShrink: 0,
+        borderRadius: compact ? 1.5 : 2,
+      }}
+    >
+      <Box
+        component="img"
+        src={logo}
+        alt=""
+        sx={{ width: "78%", height: "78%", objectFit: "contain" }}
+      />
+    </Box>
+  );
+
+  return (
+    <Box
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 1,
+        minWidth: 0,
+        borderRadius: 2,
+        px: compact ? 0.5 : 0.75,
+        py: 0.5,
+        color: "inherit",
+        textDecoration: "none",
+        "&:hover": {
+          backgroundColor: "action.hover",
+        },
+      }}
+    >
+      {externalLogo ? (
+        <MuiLink
+          href={OFF_URL}
+          target="_blank"
+          aria-label="Open Food Facts"
+          sx={{ display: "flex" }}
+        >
+          {logoMark}
+        </MuiLink>
+      ) : (
+        <Box
+          component={Link as React.ElementType}
+          to="/"
+          aria-label={t("menu.title")}
+          sx={{ display: "flex" }}
+        >
+          {logoMark}
+        </Box>
+      )}
+      <Box
+        component={Link as React.ElementType}
+        to="/"
+        sx={{
+          minWidth: 0,
+          color: "inherit",
+          textDecoration: "none",
+          lineHeight: 1,
+        }}
+      >
+        <Typography
+          component="span"
+          sx={{
+            display: "block",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            fontSize: compact ? "0.98rem" : "1.05rem",
+            fontWeight: 800,
+            letterSpacing: "-0.025em",
+          }}
+        >
+          {t("menu.title")}
+        </Typography>
+        {!compact && (
+          <Typography
+            component="span"
+            sx={{
+              display: "block",
+              mt: 0.25,
+              fontSize: "0.58rem",
+              fontWeight: 700,
+              letterSpacing: "0.14em",
+              lineHeight: 1,
+              opacity: 0.62,
+              textTransform: "uppercase",
+            }}
+          >
+            Open Food Facts
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
 const MultiPagesButton = ({
   translationKey,
   children,
@@ -239,17 +349,21 @@ const ResponsiveAppBar = () => {
       sx={(theme) => ({
         backgroundColor: theme.palette.cafeCreme.main,
         color: theme.palette.cafeCreme.contrastText,
+        boxShadow: "none",
+        borderBottom: `1px solid ${theme.palette.divider}`,
       })}
     >
       <Container maxWidth={false}>
-        <Toolbar disableGutters>
+        <Toolbar
+          disableGutters
+          sx={{ minHeight: { xs: 58, lg: 66 }, px: { xs: 0.5, lg: 0 } }}
+        >
           {/* Mobile content */}
           <Box
             sx={{
               flexGrow: 1,
               display: { xs: "flex", lg: "none" },
               alignItems: "center",
-              justifyContent: "space-between",
               maxWidth: "100%",
             }}
           >
@@ -392,28 +506,31 @@ const ResponsiveAppBar = () => {
               </Menu>
             )}
 
-            <Typography
-              variant="h5"
-              noWrap
-              component={Link as React.ElementType}
-              to="/"
+            <Box
               sx={{
-                flexGrow: 0,
-                fontFamily: "monospace",
-                fontWeight: 700,
-                letterSpacing: ".3rem",
-                color: "inherit",
-                textDecoration: "none",
-                textAlign: "center",
+                flex: 1,
+                minWidth: 0,
+                display: "flex",
+                justifyContent: "center",
               }}
             >
-              Hunger Games
-            </Typography>
+              <NavBrand compact />
+            </Box>
             {isLoggedIn ? (
-              <AccountCircleIcon color="success" />
+              <Box
+                sx={{
+                  width: 48,
+                  height: 48,
+                  display: "grid",
+                  placeItems: "center",
+                }}
+              >
+                <AccountCircleIcon color="success" />
+              </Box>
             ) : (
               <IconButton
                 aria-label={t("menu.log_in")}
+                sx={{ width: 48, height: 48 }}
                 onClick={() =>
                   void (async () => {
                     const isLoggedIn = await refresh();
@@ -450,39 +567,13 @@ const ResponsiveAppBar = () => {
                 "&::-webkit-scrollbar": { display: "none" },
               }}
             >
-              <MuiLink
-                sx={{ mr: 1, display: "flex", alignSelf: "center" }}
-                href={OFF_URL}
-                target="_blank"
-              >
-                <img
-                  src={logo}
-                  width="30px"
-                  height="30px"
-                  alt="OpenFoodFact logo"
-                />
-              </MuiLink>
-              <Typography
-                variant="h6"
-                component={Link as React.ElementType}
-                to="/"
-                sx={{
-                  mr: 2,
-                  fontFamily: "monospace",
-                  fontWeight: 700,
-                  letterSpacing: ".3rem",
-                  color: "inherit",
-                  textDecoration: "none",
-                }}
-              >
-                Hunger Games
-              </Typography>
+              <NavBrand externalLogo />
               <Divider
                 orientation="vertical"
                 sx={{
                   height: 32,
                   alignSelf: "center",
-                  mx: { lg: 0.5, xl: 1 },
+                  mx: { lg: 1, xl: 1.5 },
                   borderColor: "divider",
                 }}
               />

--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -2,6 +2,7 @@
   "home": {
     "game_selector": {
       "title": "What game would you like to play?",
+      "external_link": "External link",
       "cards": {
         "questions": {
           "title": "Questions",
@@ -28,6 +29,12 @@
       "contribution_details": "Learn why your contribution matters"
     },
     "saved_filters": "Saved Filters",
+    "saved_filters_delete": "Delete saved filter",
+    "saved_filters_delete_title": "Delete saved filter?",
+    "saved_filters_delete_description": "This saved filter will be removed from this device.",
+    "saved_filters_delete_confirm": "Delete",
+    "saved_filters_pending": "{{count}} products waiting",
+    "saved_filters_pending_unknown": "Products waiting",
     "contribution_modal": {
       "title": "Your contribution matters",
       "information": "Hunger Games is an effort to leverage the results of our OCR and artificial intelligence. When you use Hunger Games by Open Food Facts, you improve our entire database which helps the community make better food choices. We gather your annotations and use them to make Open Food Facts more accurate and efficient.",
@@ -35,6 +42,12 @@
     },
     "statistics": {
       "title": "{{userName}} statistics:",
+      "title_without_name": "Your statistics",
+      "empty_state": {
+        "title": "No contributions yet",
+        "description": "Your contribution statistics will appear here once you start helping improve Open Food Facts.",
+        "action": "Start contributing"
+      },
       "editorCount": {
         "title": "Editor",
         "description": "Number of editions done"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2,6 +2,7 @@
   "home": {
     "game_selector": {
       "title": "What game would you like to play?",
+      "external_link": "External link",
       "cards": {
         "questions": {
           "title": "Questions",
@@ -28,6 +29,12 @@
       "contribution_details": "Learn why your contribution matters"
     },
     "saved_filters": "Saved Filters",
+    "saved_filters_delete": "Delete saved filter",
+    "saved_filters_delete_title": "Delete saved filter?",
+    "saved_filters_delete_description": "This saved filter will be removed from this device.",
+    "saved_filters_delete_confirm": "Delete",
+    "saved_filters_pending": "{{count}} products waiting",
+    "saved_filters_pending_unknown": "Products waiting",
     "contribution_modal": {
       "title": "Your contribution matters",
       "information": "Hunger Games is an effort to leverage the results of our OCR and artificial intelligence. When you use Hunger Games by Open Food Facts, you improve our entire database which helps the community make better food choices. We gather your annotations and use them to make Open Food Facts more accurate and efficient.",
@@ -35,6 +42,12 @@
     },
     "statistics": {
       "title": "{{userName}} statistics:",
+      "title_without_name": "Your statistics",
+      "empty_state": {
+        "title": "No contributions yet",
+        "description": "Your contribution statistics will appear here once you start helping improve Open Food Facts.",
+        "action": "Start contributing"
+      },
       "editorCount": {
         "title": "Editor",
         "description": "Number of editions done"

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -2,6 +2,7 @@
   "home": {
     "game_selector": {
       "title": "A quale gioco vorresti giocare?",
+      "external_link": "Link esterno",
       "cards": {
         "questions": {
           "title": "Domande",
@@ -24,6 +25,12 @@
       "contribution_details": "Scopri perché il tuo contributo è importante"
     },
     "saved_filters": "Filtri salvati",
+    "saved_filters_delete": "Elimina filtro salvato",
+    "saved_filters_delete_title": "Eliminare il filtro salvato?",
+    "saved_filters_delete_description": "Questo filtro salvato verrà rimosso da questo dispositivo.",
+    "saved_filters_delete_confirm": "Elimina",
+    "saved_filters_pending": "{{count}} prodotti in attesa",
+    "saved_filters_pending_unknown": "Prodotti in attesa",
     "contribution_modal": {
       "title": "Il tuo contributo è importante",
       "information": "Hunger Games è un tentativo di sfruttare i risultati del nostro OCR e dell'intelligenza artificiale. Quando utilizzi Hunger Games di Open Food Facts, migliori il nostro intero database, il che aiuta la comunità a fare scelte alimentari migliori. Raccogliamo le tue annotazioni e le utilizziamo per rendere Open Food Facts più accurato ed efficiente.",
@@ -31,6 +38,12 @@
     },
     "statistics": {
       "title": "Statistiche di {{userName}}:",
+      "title_without_name": "Le tue statistiche",
+      "empty_state": {
+        "title": "Ancora nessun contributo",
+        "description": "Le tue statistiche dei contributi appariranno qui quando inizierai ad aiutare a migliorare Open Food Facts.",
+        "action": "Inizia a contribuire"
+      },
       "editorCount": {
         "title": "Editore",
         "description": "Numero di modifiche effettuate"

--- a/src/pages/home/UserData.tsx
+++ b/src/pages/home/UserData.tsx
@@ -8,14 +8,17 @@ import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 import Skeleton from "@mui/material/Skeleton";
 import CardActionArea from "@mui/material/CardActionArea";
+import Button from "@mui/material/Button";
 import EditIcon from "@mui/icons-material/Edit";
 import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
 import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
+import VolunteerActivismIcon from "@mui/icons-material/VolunteerActivism";
 import { SvgIconProps } from "@mui/material";
+import { Link } from "react-router";
 
 import { offClient } from "../../off";
 import { OFF_URL } from "../../const";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 
 type StatDetail = {
   translationKey: string;
@@ -26,6 +29,8 @@ type StatDetail = {
 
 type CountCardProps = StatDetail & {
   userName: string;
+  value?: number;
+  isPending: boolean;
 };
 
 type UserDataProps = {
@@ -53,32 +58,41 @@ const STATS: StatDetail[] = [
   },
 ];
 
-const CountCard = (props: CountCardProps) => {
-  const { translationKey, apiFacet, linkFacet, Icon, userName } = props;
-
+const CountCard = ({
+  translationKey,
+  linkFacet,
+  Icon,
+  userName,
+  value,
+  isPending,
+}: CountCardProps) => {
   const { t } = useTranslation();
-
-  const { data: value, isPending } = useQuery({
-    queryKey: ["userStat", apiFacet, userName],
-    queryFn: () =>
-      offClient
-        .getFacetValue(apiFacet, userName, {})
-        .then((response) => response.count)
-        .catch(() => undefined),
-  });
 
   const href = userName
     ? `${OFF_URL}/facets/${linkFacet}/${encodeURIComponent(userName)}`
     : undefined;
 
   const content = (
-    <CardContent>
-      <Stack direction="row" spacing={1} sx={{ alignItems: "center", mb: 0 }}>
-        <Icon fontSize="small" sx={{ color: "text.secondary" }} />
+    <CardContent sx={{ p: 2.5 }}>
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
+        <Box
+          sx={{
+            width: 38,
+            height: 38,
+            display: "grid",
+            placeItems: "center",
+            borderRadius: 2,
+            color: "primary.main",
+            backgroundColor: "action.selected",
+          }}
+        >
+          <Icon fontSize="small" />
+        </Box>
         <Typography
           sx={{
             color: "text.primary",
-            fontSize: 18,
+            fontSize: 17,
+            fontWeight: 700,
           }}
         >
           {t(`home.statistics.${translationKey}.title`)}
@@ -89,6 +103,7 @@ const CountCard = (props: CountCardProps) => {
         sx={{
           color: "text.secondary",
           fontSize: 15,
+          mt: 2,
           mb: 1,
         }}
       >
@@ -102,16 +117,25 @@ const CountCard = (props: CountCardProps) => {
           component="div"
           sx={{
             color: "text.primary",
+            fontWeight: 700,
           }}
         >
-          {typeof value === "number" ? value.toLocaleString() : "N/A"}
+          {typeof value === "number" ? value.toLocaleString() : "0"}
         </Typography>
       )}
     </CardContent>
   );
 
   return (
-    <Card sx={{ width: 300 }} elevation={3}>
+    <Card
+      sx={(theme) => ({
+        width: "100%",
+        height: "100%",
+        borderRadius: 3,
+        border: `1px solid ${theme.palette.divider}`,
+        boxShadow: "none",
+      })}
+    >
       {href ? (
         <CardActionArea
           component="a"
@@ -119,6 +143,7 @@ const CountCard = (props: CountCardProps) => {
           target="_blank"
           rel="noreferrer"
           aria-label={t(`home.statistics.${translationKey}.title`)}
+          sx={{ height: "100%" }}
         >
           {content}
         </CardActionArea>
@@ -131,19 +156,125 @@ const CountCard = (props: CountCardProps) => {
 
 const UserData = ({ userName }: UserDataProps) => {
   const { t } = useTranslation();
+  const statQueries = useQueries({
+    queries: STATS.map(({ apiFacet }) => ({
+      queryKey: ["userStat", apiFacet, userName],
+      queryFn: () =>
+        offClient
+          .getFacetValue(apiFacet, userName, {})
+          .then((response) => response.count)
+          .catch(() => undefined),
+    })),
+  });
+  const isPending = statQueries.some((query) => query.isPending);
+  const availableStats = STATS.map((stat, index) => ({
+    ...stat,
+    value: statQueries[index].data,
+  })).filter(({ value }) => typeof value === "number");
 
   return (
-    <Box sx={{ p: 2, mb: 10 }}>
-      <Typography component="h3" variant="h5" sx={{ pb: 3 }}>
-        {t("home.statistics.title", { userName: userName || "<unknown>" })}
+    <Box
+      component="section"
+      aria-labelledby="user-statistics-title"
+      sx={{ mt: 6 }}
+    >
+      <Typography
+        id="user-statistics-title"
+        component="h2"
+        variant="h5"
+        sx={{ pb: 2.5, fontWeight: 700 }}
+      >
+        {t(
+          userName
+            ? "home.statistics.title"
+            : "home.statistics.title_without_name",
+          { userName },
+        )}
       </Typography>
 
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-        {STATS.map((stat) => (
-          <CountCard key={stat.translationKey} {...stat} userName={userName} />
-        ))}
-      </Stack>
+      {isPending ? (
+        <StatsGrid>
+          {STATS.map((stat) => (
+            <CountCard
+              key={stat.translationKey}
+              {...stat}
+              userName={userName}
+              isPending
+            />
+          ))}
+        </StatsGrid>
+      ) : availableStats.length > 0 ? (
+        <StatsGrid>
+          {availableStats.map((stat) => (
+            <CountCard
+              key={stat.translationKey}
+              {...stat}
+              userName={userName}
+              isPending={false}
+            />
+          ))}
+        </StatsGrid>
+      ) : (
+        <Box
+          sx={(theme) => ({
+            display: "flex",
+            alignItems: { xs: "flex-start", sm: "center" },
+            flexDirection: { xs: "column", sm: "row" },
+            gap: 2,
+            p: { xs: 2, sm: 2.5 },
+            borderRadius: 3,
+            border: `1px solid ${theme.palette.divider}`,
+            backgroundColor: theme.palette.action.hover,
+          })}
+        >
+          <Box
+            sx={{
+              width: 42,
+              height: 42,
+              display: "grid",
+              placeItems: "center",
+              flexShrink: 0,
+              borderRadius: 2,
+              color: "primary.main",
+              backgroundColor: "action.selected",
+            }}
+          >
+            <VolunteerActivismIcon aria-hidden />
+          </Box>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              {t("home.statistics.empty_state.title")}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {t("home.statistics.empty_state.description")}
+            </Typography>
+          </Box>
+          <Button
+            component={Link as React.ElementType}
+            to="/questions"
+            variant="contained"
+            sx={{ flexShrink: 0 }}
+          >
+            {t("home.statistics.empty_state.action")}
+          </Button>
+        </Box>
+      )}
     </Box>
   );
 };
+
+const StatsGrid = ({ children }: { children: React.ReactNode }) => (
+  <Box
+    sx={{
+      display: "grid",
+      gridTemplateColumns: {
+        xs: "1fr",
+        sm: "repeat(3, minmax(0, 1fr))",
+      },
+      gap: 2,
+    }}
+  >
+    {children}
+  </Box>
+);
 export default UserData;

--- a/src/pages/home/homeCards.jsx
+++ b/src/pages/home/homeCards.jsx
@@ -1,13 +1,16 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
-import Card from "@mui/material/Card";
-import CardMedia from "@mui/material/CardMedia";
-import CardContent from "@mui/material/CardContent";
-import CardActionArea from "@mui/material/CardActionArea";
-import Typography from "@mui/material/Typography";
-import Stack from "@mui/material/Stack";
-import Box from "@mui/material/Box";
+
 import AddShoppingCartIcon from "@mui/icons-material/AddShoppingCart";
+import ArrowForwardRoundedIcon from "@mui/icons-material/ArrowForwardRounded";
+import OpenInNewRoundedIcon from "@mui/icons-material/OpenInNewRounded";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
+import CardContent from "@mui/material/CardContent";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import home_questions from "../../assets/home_questions.svg";
 import home_logos from "../../assets/home_logos.svg";
 
@@ -39,74 +42,126 @@ const cards = [
   },
 ];
 
+const HomeCard = ({ cardInfo, t }) => {
+  const { title, desc, image, Icon } = cardInfo;
+  const actionProps = cardInfo.href
+    ? {
+        component: "a",
+        href: cardInfo.href,
+        target: "_blank",
+        rel: "noreferrer",
+      }
+    : { component: Link, to: cardInfo.link };
+
+  return (
+    <Card
+      sx={(theme) => ({
+        minWidth: 0,
+        height: "100%",
+        borderRadius: 3,
+        border: `1px solid ${theme.palette.divider}`,
+        boxShadow: "none",
+        transition: theme.transitions.create(["transform", "box-shadow"]),
+        "&:hover": {
+          transform: "translateY(-2px)",
+          boxShadow: theme.shadows[2],
+        },
+      })}
+    >
+      <CardActionArea
+        {...actionProps}
+        sx={{
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "stretch",
+        }}
+      >
+        <Box
+          sx={(theme) => ({
+            height: { xs: 170, sm: 190 },
+            display: "grid",
+            placeItems: "center",
+            backgroundColor:
+              theme.palette.mode === "dark"
+                ? theme.palette.background.paper
+                : theme.palette.secondary.light,
+          })}
+        >
+          {Icon ? (
+            <Icon
+              sx={(theme) => ({
+                fontSize: 84,
+                color: theme.palette.primary.main,
+              })}
+              aria-hidden
+            />
+          ) : (
+            <Box
+              component="img"
+              src={image}
+              alt={t(title)}
+              sx={{
+                width: "80%",
+                height: "80%",
+                objectFit: "contain",
+              }}
+            />
+          )}
+        </Box>
+        <CardContent sx={{ flexGrow: 1, p: 2.5 }}>
+          <Typography component="h3" variant="h6" sx={{ fontWeight: 700 }}>
+            {t(title)}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            {t(desc)}
+          </Typography>
+        </CardContent>
+        <Stack
+          direction="row"
+          sx={{
+            px: 2.5,
+            pb: 2.25,
+            alignItems: "center",
+            justifyContent: "space-between",
+            color: "primary.main",
+          }}
+        >
+          {cardInfo.href && (
+            <Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+              <OpenInNewRoundedIcon fontSize="small" aria-hidden />
+              <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                {t("home.game_selector.external_link")}
+              </Typography>
+            </Stack>
+          )}
+          <ArrowForwardRoundedIcon fontSize="small" aria-hidden />
+        </Stack>
+      </CardActionArea>
+    </Card>
+  );
+};
+
 const HomeCards = () => {
   const { t } = useTranslation();
+
   return (
-    <Stack
-      spacing={3}
-      direction={{ xs: "column", sm: "column", md: "row" }}
+    <Box
       sx={{
-        alignItems: "center",
-        justifyContent: "center",
-        marginBottom: "30px",
+        display: "grid",
+        gridTemplateColumns: {
+          xs: "1fr",
+          sm: "repeat(2, minmax(0, 1fr))",
+          lg: "repeat(4, minmax(0, 1fr))",
+        },
+        gap: 2.5,
+        alignItems: "stretch",
       }}
     >
       {cards.map((cardInfo) => (
-        <Card sx={{ width: 350, height: 300 }} key={cardInfo.title}>
-          <CardActionArea
-            {...(cardInfo.href
-              ? {
-                  component: "a",
-                  href: cardInfo.href,
-                  target: "_blank",
-                  rel: "noreferrer",
-                }
-              : { component: Link, to: cardInfo.link })}
-          >
-            {cardInfo.Icon ? (
-              <Box
-                sx={{
-                  height: 200,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  backgroundColor: "#f6f3f0",
-                  borderRadius: "16px",
-                }}
-              >
-                <cardInfo.Icon
-                  sx={{ fontSize: 96, color: "#85746c" }}
-                  aria-hidden
-                />
-              </Box>
-            ) : (
-              <CardMedia
-                component="img"
-                height="200"
-                image={cardInfo.image}
-                alt={t(cardInfo.title)}
-                sx={{ objectFit: "contain" }}
-              />
-            )}
-            <CardContent>
-              <Typography variant="h5" component="div">
-                {t(cardInfo.title)}
-              </Typography>
-              <Typography
-                gutterBottom
-                variant="p"
-                component="div"
-                sx={{
-                  fontSize: 14,
-                }}
-              >
-                {t(cardInfo.desc)}
-              </Typography>
-            </CardContent>
-          </CardActionArea>
-        </Card>
+        <HomeCard key={cardInfo.title} cardInfo={cardInfo} t={t} />
       ))}
-    </Stack>
+    </Box>
   );
 };
 

--- a/src/pages/home/index.jsx
+++ b/src/pages/home/index.jsx
@@ -4,15 +4,22 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/material/styles";
 
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Container from "@mui/material/Container";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Divider from "@mui/material/Divider";
+import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
-import Divider from "@mui/material/Divider";
-import Modal from "@mui/material/Modal";
 
 import { OFF_URL } from "../../const";
 import QuestionCard from "../../components/QuestionCard";
 import FooterWithLinks from "../../components/Footer";
+import logo from "../../assets/logo.png";
 import HomeCards from "./homeCards";
 import UserData from "./UserData";
 
@@ -20,164 +27,300 @@ import { localFavorites } from "../../localeStorageManager";
 import LoginContext from "../../contexts/login";
 import Loader from "../loader";
 
-const Home = () => {
-  const theme = useTheme();
+const HomeHero = () => {
   const { t } = useTranslation();
-  const [savedQuestions] = React.useState(() => {
-    return localFavorites.fetch().questions ?? [];
-  });
+  const theme = useTheme();
 
-  const { isLoggedIn, userName } = React.useContext(LoginContext);
-
-  const size = Object.keys(savedQuestions).length;
-  const [open, setOpen] = React.useState(false);
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
   return (
-    <React.Suspense fallback={<Loader />}>
-      <Box sx={{ p: 2, alignItems: "center" }}>
-        <Typography
-          variant="h5"
-          sx={{ margin: "20px auto", textAlign: "center" }}
-        >
-          {t("home.game_selector.title")}
-        </Typography>
-        <HomeCards />
-        {size > 0 && (
-          <Typography
-            variant="h5"
-            sx={{ margin: "40px auto", textAlign: "center" }}
-          >
-            {t("home.saved_filters")}
-          </Typography>
-        )}
-        <Stack
-          spacing={4}
-          direction="row"
+    <Paper
+      component="section"
+      elevation={0}
+      aria-labelledby="home-title"
+      sx={{
+        position: "relative",
+        overflow: "hidden",
+        px: { xs: 3, sm: 5, md: 7 },
+        py: { xs: 2.75, sm: 3.5 },
+        borderRadius: 3,
+        color: theme.palette.cafeCreme.contrastText,
+        backgroundColor: theme.palette.cafeCreme.main,
+        border: `1px solid ${theme.palette.divider}`,
+        "&::after": {
+          content: '""',
+          position: "absolute",
+          width: 180,
+          height: 180,
+          right: { xs: -100, sm: -50 },
+          top: -110,
+          borderRadius: "50%",
+          backgroundColor: theme.palette.action.hover,
+        },
+      }}
+    >
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        spacing={{ xs: 2.5, sm: 4 }}
+        sx={{ position: "relative", zIndex: 1, alignItems: "center" }}
+      >
+        <Box
           sx={{
-            flexWrap: "wrap",
+            flexShrink: 0,
+            width: { xs: 68, sm: 84 },
+            height: { xs: 68, sm: 84 },
+            display: "grid",
+            placeItems: "center",
+            borderRadius: "32%",
           }}
         >
-          {savedQuestions.map((props) => (
-            <Box sx={{ marginBottom: 5 }} key={props.title}>
-              <QuestionCard showFilterResume editableTitle {...props} />
-            </Box>
-          ))}
-        </Stack>
-      </Box>
-
-      {isLoggedIn ? (
-        <UserData userName={userName} />
-      ) : (
-        <React.Fragment>
           <Box
+            component="img"
+            src={logo}
+            alt=""
+            sx={{ width: "72%", height: "72%", objectFit: "contain" }}
+          />
+        </Box>
+        <Box sx={{ textAlign: { xs: "center", sm: "left" } }}>
+          <Typography
+            variant="overline"
             sx={{
-              padding: { xs: "20px", sm: "50px" },
-              backgroundColor: theme.palette.action.selected,
+              display: "block",
+              fontWeight: 700,
+              letterSpacing: "0.16em",
+              opacity: 0.78,
             }}
           >
-            <Stack
-              spacing={4}
-              direction={{ xs: "column", sm: "column", md: "row" }}
-              sx={{
-                flexWrap: "wrap",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <Typography
-                variant="h5"
-                sx={{
-                  textAlign: "center",
-                  lineHeight: "1.75",
-                }}
-              >
-                {t("home.account_band.title")}
-              </Typography>
-              <Stack direction="row">
-                <Button
-                  variant="contained"
-                  href={`${OFF_URL}/cgi/login.pl`}
-                  sx={{
-                    margin: "0 20px",
-                  }}
-                >
-                  {t("home.account_band.log_in")}
-                </Button>
-                <Button variant="outlined" href={`${OFF_URL}/cgi/user.pl`}>
-                  {t("home.account_band.sign_up")}
-                </Button>
-              </Stack>
-            </Stack>
-          </Box>
-          <Box
+            {t("menu.title")}
+          </Typography>
+          <Typography
+            id="home-title"
+            component="h1"
+            variant="h3"
             sx={{
-              textAlign: "center",
+              fontWeight: 800,
+              lineHeight: 1.1,
+              fontSize: { xs: "1.75rem", sm: "2.35rem" },
             }}
+          >
+            {t("home.game_selector.title")}
+          </Typography>
+        </Box>
+      </Stack>
+      <Divider sx={{ my: { xs: 2.5, sm: 3 }, borderColor: "divider" }} />
+      <HomeCards />
+    </Paper>
+  );
+};
+
+const SavedFilters = ({ savedQuestions, onDelete }) => {
+  const { t } = useTranslation();
+  const [filterToDelete, setFilterToDelete] = React.useState(null);
+
+  if (savedQuestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      component="section"
+      aria-labelledby="saved-filters-title"
+      sx={{ mt: 6 }}
+    >
+      <Stack
+        direction="row"
+        spacing={1.5}
+        sx={{ alignItems: "center", mb: 2.5 }}
+      >
+        <Typography
+          id="saved-filters-title"
+          component="h2"
+          variant="h5"
+          sx={{ fontWeight: 700 }}
+        >
+          {t("home.saved_filters")}
+        </Typography>
+        <Chip label={savedQuestions.length} size="small" color="primary" />
+      </Stack>
+      <Box sx={{ display: "grid", gap: 1.5 }}>
+        {savedQuestions.map((props) => (
+          <QuestionCard
+            key={props.title}
+            showFilterResume
+            editableTitle
+            compact
+            onDelete={() => setFilterToDelete(props)}
+            {...props}
+          />
+        ))}
+      </Box>
+      <Dialog
+        open={Boolean(filterToDelete)}
+        onClose={() => setFilterToDelete(null)}
+        fullWidth
+        maxWidth="xs"
+        aria-labelledby="delete-saved-filter-title"
+      >
+        <DialogTitle id="delete-saved-filter-title" sx={{ fontWeight: 700 }}>
+          {t("home.saved_filters_delete_title")}
+        </DialogTitle>
+        <DialogContent>
+          <Typography>{t("home.saved_filters_delete_description")}</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setFilterToDelete(null)}>
+            {t("questions.filters.actions.cancel")}
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => {
+              if (filterToDelete) {
+                onDelete(filterToDelete);
+                setFilterToDelete(null);
+              }
+            }}
+          >
+            {t("home.saved_filters_delete_confirm")}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+const AccountPrompt = ({ onLearnMore }) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  return (
+    <Box
+      component="section"
+      aria-labelledby="account-prompt-title"
+      sx={{ mt: 6 }}
+    >
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 3, sm: 4 },
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.divider}`,
+          backgroundColor: theme.palette.action.selected,
+        }}
+      >
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={3}
+          sx={{ alignItems: { xs: "stretch", md: "center" } }}
+        >
+          <Typography
+            id="account-prompt-title"
+            component="h2"
+            variant="h5"
+            sx={{ flex: 1, fontWeight: 700, lineHeight: 1.35 }}
+          >
+            {t("home.account_band.title")}
+          </Typography>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={1.5}
+            sx={{ flexShrink: 0 }}
           >
             <Button
-              onClick={handleOpen}
-              sx={{
-                margin: "20px auto",
-              }}
+              variant="contained"
+              size="large"
+              href={`${OFF_URL}/cgi/login.pl`}
             >
-              {t("home.account_band.contribution_details")}
+              {t("home.account_band.log_in")}
             </Button>
-          </Box>
-          <Divider />
-
-          <Modal
-            open={open}
-            onClose={handleClose}
-            aria-labelledby="modal-contribution-title"
-            aria-describedby="modal-contribution-information"
-          >
-            <Box
-              sx={{
-                width: { xs: "90%", sm: "50%" },
-                backgroundColor: theme.palette.secondary.main,
-                color: theme.palette.secondary.contrastText,
-                position: "absolute",
-                left: "50%",
-                top: "50%",
-                transform: "translate(-50%, -50%)",
-                padding: "20px",
-              }}
+            <Button
+              variant="outlined"
+              size="large"
+              href={`${OFF_URL}/cgi/user.pl`}
             >
-              <Typography
-                id="modal-contribution-title"
-                variant="h6"
-                component="h2"
-                sx={{
-                  fontWeight: 700,
-                }}
-              >
-                {t("home.contribution_modal.title")}
-              </Typography>
-              <Typography
-                class="modal-contribution-information"
-                sx={{ mt: 2 }}
-                component="p"
-              >
-                {t("home.contribution_modal.information")}
-              </Typography>
-              <Typography
-                class="modal-contribution-information"
-                sx={{ mt: 2 }}
-                component="p"
-              >
-                {t("home.contribution_modal.thank_you")}
-              </Typography>
-            </Box>
-          </Modal>
-        </React.Fragment>
-      )}
+              {t("home.account_band.sign_up")}
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+      <Box sx={{ textAlign: "center", mt: 1.5 }}>
+        <Button onClick={onLearnMore}>
+          {t("home.account_band.contribution_details")}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
 
-      <Divider
-        sx={{
-          width: "100%",
-          opacity: "0.6",
-        }}
+const ContributionDialog = ({ open, onClose }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      aria-labelledby="contribution-dialog-title"
+    >
+      <DialogTitle id="contribution-dialog-title" sx={{ fontWeight: 700 }}>
+        {t("home.contribution_modal.title")}
+      </DialogTitle>
+      <DialogContent dividers>
+        <Typography component="p">
+          {t("home.contribution_modal.information")}
+        </Typography>
+        <Typography component="p" sx={{ mt: 2 }}>
+          {t("home.contribution_modal.thank_you")}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>
+          {t("questions.filters.actions.cancel")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const Home = () => {
+  const [savedQuestions, setSavedQuestions] = React.useState(() => {
+    return localFavorites.fetch().questions ?? [];
+  });
+  const { isLoggedIn, userName } = React.useContext(LoginContext);
+  const [isContributionDialogOpen, setContributionDialogOpen] =
+    React.useState(false);
+  const handleDeleteSavedFilter = (questionToDelete) => {
+    localFavorites.removeQuestion(questionToDelete.filterState);
+    setSavedQuestions((questions) =>
+      questions.filter((question) => question !== questionToDelete),
+    );
+  };
+
+  return (
+    <React.Suspense fallback={<Loader />}>
+      <Box
+        component="main"
+        sx={(theme) => ({
+          background: `linear-gradient(180deg, ${theme.palette.background.default} 0%, ${theme.palette.action.hover} 100%)`,
+        })}
+      >
+        <Container maxWidth="lg" sx={{ py: { xs: 3, sm: 5 } }}>
+          <HomeHero />
+          <SavedFilters
+            savedQuestions={savedQuestions}
+            onDelete={handleDeleteSavedFilter}
+          />
+          {isLoggedIn ? (
+            <UserData userName={userName} />
+          ) : (
+            <AccountPrompt
+              onLearnMore={() => setContributionDialogOpen(true)}
+            />
+          )}
+        </Container>
+      </Box>
+      <ContributionDialog
+        open={isContributionDialogOpen}
+        onClose={() => setContributionDialogOpen(false)}
       />
       <FooterWithLinks />
     </React.Suspense>


### PR DESCRIPTION
## Summary

- Redesign the homepage hero, game cards, saved filters, account prompt, and contribution stats.
- Modernize the navbar and footer with responsive MUI layouts.
- Add saved-filter deletion, localized empty states, and client-side internal navigation.

## Validation

- `yarn lint`
- `yarn build`