### PR TITLE
feat: redesign Green-Score page

### DIFF
--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -16,9 +16,18 @@ self.addEventListener('install', (event) => {
 
 // Listen for requests
 self.addEventListener('fetch', (event) => {
+	const requestUrl = new URL(event.request.url);
+	if (
+		requestUrl.origin !== self.location.origin ||
+		event.request.method !== 'GET' ||
+		event.request.mode !== 'navigate'
+	) {
+		return;
+	}
+
 	event.respondWith(
-		caches.match(event.request).then(() => {
-			return fetch(event.request).catch(() => caches.match('offline.html'));
+		fetch(event.request).catch(() => {
+			return caches.match('offline.html');
 		})
 	);
 });

--- a/src/components/Opportunities.tsx
+++ b/src/components/Opportunities.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Link } from "react-router";
+import { useTranslation } from "react-i18next";
 
 import Typography from "@mui/material/Typography";
 import Card from "@mui/material/Card";
@@ -8,6 +9,7 @@ import CardContent from "@mui/material/CardContent";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
 import { useInfiniteQuery, useQueries } from "@tanstack/react-query";
 
 import Loader from "../pages/loader";
@@ -45,21 +47,39 @@ const OpportunityCard = (props: OpportunityCardProps) => {
   return (
     <React.Suspense fallback={<Loader />}>
       <Card
-        sx={{
-          minWidth: 250,
-        }}
         variant="outlined"
+        sx={(theme) => ({
+          minWidth: 0,
+          height: "100%",
+          borderRadius: 3,
+          boxShadow: "none",
+          transition: theme.transitions.create(["transform", "box-shadow"]),
+          "&:hover": {
+            transform: "translateY(-2px)",
+            boxShadow: theme.shadows[2],
+          },
+        })}
       >
         <CardActionArea
           component={Link as React.ElementType}
           to={targetUrl}
           sx={{ height: "100%" }}
         >
-          <CardContent>
-            <Typography variant="h6">{name}</Typography>
-            <Typography sx={{ textAlign: "end", mt: 3, fontSize: "1.5rem" }}>
-              {questionNumber.toLocaleString()}
+          <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
+            <Typography variant="h6" sx={{ fontWeight: 700, lineHeight: 1.25 }}>
+              {name}
             </Typography>
+            <Stack
+              direction="row"
+              sx={{ alignItems: "baseline", justifyContent: "flex-end", mt: 3 }}
+            >
+              <Typography
+                color="primary"
+                sx={{ fontSize: "1.75rem", fontWeight: 800, lineHeight: 1 }}
+              >
+                {questionNumber.toLocaleString()}
+              </Typography>
+            </Stack>
           </CardContent>
         </CardActionArea>
       </Card>
@@ -70,14 +90,13 @@ const OpportunityCard = (props: OpportunityCardProps) => {
 const CardSkeleton = () => (
   <React.Suspense fallback={<Loader />}>
     <Card
-      sx={{
-        minWidth: 250,
-      }}
+      variant="outlined"
+      sx={{ minWidth: 0, borderRadius: 3, boxShadow: "none" }}
     >
-      <CardContent>
-        <Skeleton variant="rectangular" width={200} height={40} />
+      <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
+        <Skeleton variant="rounded" width="80%" height={28} />
         <Skeleton
-          variant="rectangular"
+          variant="rounded"
           width={100}
           height={50}
           sx={{ mt: 3, ml: "auto", fontSize: "1.5rem" }}
@@ -126,6 +145,7 @@ const useCategoryTranslations = (pages: Opportunity[][]) => {
 
 const Opportunities = (props: OpportunitiesProps) => {
   const { type, campaign, countryCode } = props;
+  const { t } = useTranslation();
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
     useInfiniteQuery({
       queryKey: ["opportunities", type, campaign, countryCode],
@@ -144,7 +164,11 @@ const Opportunities = (props: OpportunitiesProps) => {
         lastPage.length < pageSize ? undefined : pages.length + 1,
     });
   const remainingQuestions = React.useMemo(
-    () => data?.pages.flat() ?? [],
+    () =>
+      [...(data?.pages.flat() ?? [])].sort(
+        ([, firstQuestionNumber], [, secondQuestionNumber]) =>
+          secondQuestionNumber - firstQuestionNumber,
+      ),
     [data?.pages],
   );
   const translation = useCategoryTranslations(data?.pages ?? []);
@@ -152,15 +176,16 @@ const Opportunities = (props: OpportunitiesProps) => {
   const lang = getLang() ?? "en";
   return (
     <React.Suspense fallback={<Loader />}>
-      <Box sx={{ mt: 2, px: 2 }}>
-        <Typography variant="h6" component="h3">
-          {type}
-        </Typography>
+      <Box>
         <Box
           sx={{
             display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-            gridGap: "10px 50px",
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(3, minmax(0, 1fr))",
+            },
+            gap: { xs: 1.5, sm: 2 },
           }}
         >
           {remainingQuestions.map(([value, questionNumber]) => {
@@ -188,10 +213,10 @@ const Opportunities = (props: OpportunitiesProps) => {
           <Button
             disabled={isLoading || isFetchingNextPage || !hasNextPage}
             variant="contained"
-            fullWidth
+            sx={{ gridColumn: "1 / -1", justifySelf: "center", px: 4 }}
             onClick={() => void fetchNextPage()}
           >
-            Load more
+            {t("logos.load_more")}
           </Button>
         </Box>
       </Box>

--- a/src/components/SmallQuestionCard.tsx
+++ b/src/components/SmallQuestionCard.tsx
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 
 import {
   CircularProgress,
-  Badge,
   CardActionArea,
   CardMedia,
   Card,
   Link,
+  Box,
+  Typography,
 } from "@mui/material";
 
 import robotoff, { FilterState } from "../robotoff";
@@ -16,16 +18,24 @@ import { getQuestionSearchParams } from "./QuestionFilter";
 type SmallQuestionCardProps = {
   filterState: FilterState;
   imageSrc?: string;
+  questionNumber?: number | null;
+  questionCountLoading?: boolean;
+  title?: string;
 };
 
 export default function SmallQuestionCard({
   filterState,
   imageSrc,
+  questionNumber: providedQuestionNumber,
+  questionCountLoading,
+  title,
 }: SmallQuestionCardProps) {
+  const { t } = useTranslation();
   const targetUrl = `/questions?${getQuestionSearchParams(filterState)}`;
 
   const questionCountQuery = useQuery({
     queryKey: ["question-count", filterState],
+    enabled: providedQuestionNumber === undefined,
     queryFn: async () => {
       const { data } = await robotoff.questions(
         { ...filterState, with_image: true },
@@ -35,40 +45,93 @@ export default function SmallQuestionCard({
       return data?.count ?? 0;
     },
   });
-  const questionNumber = questionCountQuery.data ?? null;
+  const questionNumber =
+    providedQuestionNumber === undefined
+      ? (questionCountQuery.data ?? null)
+      : providedQuestionNumber;
+  const isQuestionCountLoading =
+    questionCountLoading ?? questionCountQuery.isLoading;
 
   return (
-    <Badge
-      sx={{
-        "& .MuiBadge-badge": {
-          fontSize: "1.5rem",
-          minWidth: "2rem",
-          minHeight: "2rem",
+    <Card
+      variant="outlined"
+      sx={(theme) => ({
+        width: "100%",
+        borderRadius: 3,
+        overflow: "hidden",
+        boxShadow: "none",
+        transition: theme.transitions.create(["transform", "box-shadow"]),
+        "&:hover": {
+          transform: "translateY(-2px)",
+          boxShadow: theme.shadows[2],
         },
-      }}
-      badgeContent={
-        questionNumber ?? <CircularProgress size={15} sx={{ color: "white" }} />
-      }
-      showZero
-      color={
-        questionNumber == null
-          ? "info"
-          : questionNumber > 0
-            ? "error"
-            : "success"
-      }
+      })}
     >
-      <Card sx={{ minWidth: 200, maxWidth: 350 }}>
-        <CardActionArea component={Link} href={targetUrl}>
-          <CardMedia
-            component="img"
-            height="150"
-            image={imageSrc || logo}
-            alt=""
-            sx={{ objectFit: "contain" }}
-          />
-        </CardActionArea>
-      </Card>
-    </Badge>
+      <CardActionArea
+        component={Link}
+        href={targetUrl}
+        sx={{ display: "block" }}
+      >
+        <CardMedia
+          component="img"
+          height="150"
+          image={imageSrc || logo}
+          alt={title || ""}
+          sx={(theme) => ({
+            objectFit: "contain",
+            p: 2,
+            backgroundColor:
+              theme.palette.mode === "dark"
+                ? theme.palette.background.paper
+                : theme.palette.secondary.light,
+          })}
+        />
+        <Box
+          sx={(theme) => ({
+            display: "flex",
+            flexDirection: "column",
+            minHeight: 52,
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 0.25,
+            px: 2,
+            py: 1,
+            backgroundColor: theme.palette.background.paper,
+          })}
+        >
+          {isQuestionCountLoading || questionNumber == null ? (
+            <CircularProgress size={16} sx={{ color: "text.secondary" }} />
+          ) : (
+            <>
+              <Typography
+                component="span"
+                variant="h5"
+                sx={{
+                  color: "text.primary",
+                  fontWeight: 800,
+                  lineHeight: 1.1,
+                }}
+              >
+                {questionNumber.toLocaleString()}
+              </Typography>
+              <Typography
+                component="span"
+                variant="caption"
+                sx={{
+                  color: "text.secondary",
+                  fontWeight: 700,
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                }}
+              >
+                {t("green-score.questionCountLabel", {
+                  count: questionNumber,
+                })}
+              </Typography>
+            </>
+          )}
+        </Box>
+      </CardActionArea>
+    </Card>
   );
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -423,6 +423,10 @@
   },
   "green-score": {
     "description": "Here is a summary of questions that could improve Green-Score computation",
+    "labelsDescription": "Answer questions related to these labels to improve Green-Score computation",
+    "categoriesDescription": "Answer questions related to these categories to improve Green-Score computation",
+    "questionCountLabel_one": "question",
+    "questionCountLabel_other": "questions",
     "countryLabel": "Country"
   },
   "ingredients": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -421,6 +421,10 @@
   },
   "green-score": {
     "description": "Ecco un riepilogo delle domande che potrebbero migliorare il calcolo dell'Green-Score",
+    "labelsDescription": "Rispondi alle domande relative a queste etichette per migliorare il calcolo del Green-Score",
+    "categoriesDescription": "Rispondi alle domande relative a queste categorie per migliorare il calcolo del Green-Score",
+    "questionCountLabel_one": "domanda",
+    "questionCountLabel_other": "domande",
     "countryLabel": "Paese"
   },
   "ingredients": {

--- a/src/pages/green-score/index.tsx
+++ b/src/pages/green-score/index.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
 
+import { useQueries } from "@tanstack/react-query";
 import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import MenuItem from "@mui/material/MenuItem";
-import Divider from "@mui/material/Divider";
+import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 
 import { useTranslation } from "react-i18next";
@@ -13,60 +15,234 @@ import SmallQuestionCard from "../../components/SmallQuestionCard";
 import Opportunities from "../../components/Opportunities";
 import Loader from "../loader";
 import { useCountry } from "../../contexts/CountryProvider";
+import robotoff from "../../robotoff";
 
 import countryNames from "../../assets/countries.json";
 import greenScoreCards from "./cards";
 
+const greenScoreImage =
+  "https://static.openfoodfacts.org/images/attributes/dist/green-score-a.svg";
+
 export default function GreenScore() {
   const { t } = useTranslation();
   const [country, setCountry] = useCountry();
+  const greenScoreCountQueries = useQueries({
+    queries: greenScoreCards.map(({ filterState }) => ({
+      queryKey: ["question-count", filterState],
+      queryFn: async () => {
+        const { data } = await robotoff.questions(
+          { ...filterState, with_image: true },
+          1,
+          1,
+        );
+        return data?.count ?? 0;
+      },
+    })),
+  });
+  const sortedGreenScoreCards = React.useMemo(
+    () =>
+      greenScoreCards
+        .map((card, index) => ({
+          ...card,
+          questionNumber: greenScoreCountQueries[index].data,
+          questionCountLoading: greenScoreCountQueries[index].isLoading,
+        }))
+        .sort(
+          (first, second) =>
+            (second.questionNumber ?? -1) - (first.questionNumber ?? -1),
+        ),
+    [greenScoreCountQueries],
+  );
 
   return (
     <React.Suspense fallback={<Loader />}>
-      <Stack
-        spacing={2}
-        sx={{
-          padding: 5,
-        }}
+      <Box
+        component="main"
+        sx={(theme) => ({
+          minHeight: "calc(100vh - 64px)",
+          background: `linear-gradient(180deg, ${theme.palette.background.default} 0%, ${theme.palette.action.hover} 100%)`,
+        })}
       >
-        <Typography>{t("green-score.description")}</Typography>
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-            gridGap: "10px 50px",
-          }}
-        >
-          {greenScoreCards.map((props) => (
-            <Box key={props.title}>
-              <SmallQuestionCard {...props} />
+        <Container maxWidth="lg" sx={{ py: { xs: 3, sm: 5 } }}>
+          <Paper
+            component="section"
+            elevation={0}
+            aria-labelledby="green-score-title"
+            sx={(theme) => ({
+              position: "relative",
+              overflow: "hidden",
+              px: { xs: 3, sm: 5, md: 7 },
+              py: { xs: 3, sm: 4 },
+              borderRadius: 3,
+              border: `1px solid ${theme.palette.divider}`,
+              color: theme.palette.cafeCreme.contrastText,
+              backgroundColor: theme.palette.cafeCreme.main,
+              "&::after": {
+                content: '""',
+                position: "absolute",
+                width: 220,
+                height: 220,
+                right: { xs: -130, sm: -70 },
+                top: -130,
+                borderRadius: "50%",
+                backgroundColor: theme.palette.action.hover,
+              },
+            })}
+          >
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={{ xs: 2, sm: 3.5 }}
+              sx={{ position: "relative", zIndex: 1, alignItems: "center" }}
+            >
+              <Box
+                sx={(theme) => ({
+                  width: { xs: 92, sm: 112 },
+                  height: { xs: 92, sm: 112 },
+                  display: "grid",
+                  placeItems: "center",
+                  flexShrink: 0,
+                  borderRadius: "32%",
+                  backgroundColor: theme.palette.action.hover,
+                })}
+              >
+                <Box
+                  component="img"
+                  src={greenScoreImage}
+                  alt=""
+                  sx={{ width: "72%", height: "72%", objectFit: "contain" }}
+                />
+              </Box>
+              <Box sx={{ textAlign: { xs: "center", sm: "left" } }}>
+                <Typography
+                  variant="overline"
+                  sx={{
+                    display: "block",
+                    fontWeight: 700,
+                    letterSpacing: "0.16em",
+                    opacity: 0.78,
+                  }}
+                >
+                  {t("menu.title")}
+                </Typography>
+                <Typography
+                  id="green-score-title"
+                  component="h1"
+                  variant="h3"
+                  sx={{
+                    fontWeight: 800,
+                    lineHeight: 1.1,
+                    fontSize: { xs: "1.9rem", sm: "2.5rem" },
+                  }}
+                >
+                  {t("menu.green-score")}
+                </Typography>
+                <Typography
+                  variant="body1"
+                  sx={{ maxWidth: 620, mt: 1, opacity: 0.86 }}
+                >
+                  {t("green-score.description")}
+                </Typography>
+              </Box>
+            </Stack>
+          </Paper>
+
+          <Box
+            component="section"
+            aria-labelledby="green-score-labels-title"
+            sx={{ mt: { xs: 4, sm: 6 } }}
+          >
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1.5}
+              sx={{
+                alignItems: { xs: "flex-start", sm: "center" },
+                justifyContent: "space-between",
+                mb: 2.5,
+              }}
+            >
+              <Box>
+                <Typography
+                  id="green-score-labels-title"
+                  component="h2"
+                  variant="h4"
+                  sx={{ fontWeight: 800, lineHeight: 1.15 }}
+                >
+                  {t("questions.labels")}
+                </Typography>
+                <Typography color="text.secondary" sx={{ mt: 0.75 }}>
+                  {t("green-score.labelsDescription")}
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: {
+                  xs: "repeat(2, minmax(0, 1fr))",
+                  sm: "repeat(3, minmax(0, 1fr))",
+                  md: "repeat(4, minmax(0, 1fr))",
+                  lg: "repeat(5, minmax(0, 1fr))",
+                },
+                gap: { xs: 1.5, sm: 2 },
+              }}
+            >
+              {sortedGreenScoreCards.map((props) => (
+                <SmallQuestionCard key={props.title} {...props} />
+              ))}
             </Box>
-          ))}
-        </Box>
+          </Box>
 
-        <Divider />
-        <TextField
-          select
-          label={t("green-score.countryLabel")}
-          value={country}
-          onChange={(event) => {
-            setCountry(event.target.value, "global");
-          }}
-          sx={{ width: 200 }}
-        >
-          {countryNames.map((country) => (
-            <MenuItem value={country.countryCode} key={country.countryCode}>
-              {country.label}
-            </MenuItem>
-          ))}
-        </TextField>
-
-        <Opportunities
-          type="category"
-          countryCode={country}
-          campaign="agribalyse-category"
-        />
-      </Stack>
+          <Box component="section" sx={{ mt: { xs: 4, sm: 6 } }}>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1.5}
+              sx={{
+                alignItems: { xs: "stretch", sm: "center" },
+                justifyContent: "space-between",
+                mb: 2,
+              }}
+            >
+              <Box>
+                <Typography
+                  component="h2"
+                  variant="h4"
+                  sx={{ fontWeight: 800 }}
+                >
+                  {t("questions.categories")}
+                </Typography>
+                <Typography color="text.secondary" sx={{ mt: 0.75 }}>
+                  {t("green-score.categoriesDescription")}
+                </Typography>
+              </Box>
+              <TextField
+                select
+                size="small"
+                label={t("green-score.countryLabel")}
+                value={country}
+                onChange={(event) => {
+                  setCountry(event.target.value, "global");
+                }}
+                sx={{ width: { xs: "100%", sm: 210 }, flexShrink: 0 }}
+              >
+                {countryNames.map((country) => (
+                  <MenuItem
+                    value={country.countryCode}
+                    key={country.countryCode}
+                  >
+                    {country.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Stack>
+            <Opportunities
+              type="category"
+              countryCode={country}
+              campaign="agribalyse-category"
+            />
+          </Box>
+        </Container>
+      </Box>
     </React.Suspense>
   );
 }

--- a/src/pages/green-score/index.tsx
+++ b/src/pages/green-score/index.tsx
@@ -7,6 +7,8 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import MenuItem from "@mui/material/MenuItem";
 import Paper from "@mui/material/Paper";
+import Card from "@mui/material/Card";
+import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 
 import { useTranslation } from "react-i18next";
@@ -22,6 +24,37 @@ import greenScoreCards from "./cards";
 
 const greenScoreImage =
   "https://static.openfoodfacts.org/images/attributes/dist/green-score-a.svg";
+
+function GreenScoreCardSkeleton() {
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        width: "100%",
+        borderRadius: 3,
+        overflow: "hidden",
+        boxShadow: "none",
+      }}
+    >
+      <Skeleton variant="rectangular" animation="wave" sx={{ height: 150 }} />
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 0.25,
+          px: 2,
+          py: 1,
+          minHeight: 66,
+        }}
+      >
+        <Skeleton variant="text" width="42%" height={28} />
+        <Skeleton variant="text" width="68%" height={18} />
+      </Box>
+    </Card>
+  );
+}
 
 export default function GreenScore() {
   const { t } = useTranslation();
@@ -39,20 +72,20 @@ export default function GreenScore() {
       },
     })),
   });
-  const sortedGreenScoreCards = React.useMemo(
-    () =>
-      greenScoreCards
-        .map((card, index) => ({
-          ...card,
-          questionNumber: greenScoreCountQueries[index].data,
-          questionCountLoading: greenScoreCountQueries[index].isLoading,
-        }))
-        .sort(
-          (first, second) =>
-            (second.questionNumber ?? -1) - (first.questionNumber ?? -1),
-        ),
-    [greenScoreCountQueries],
+  const greenScoreCardsWithCounts = greenScoreCards.map((card, index) => ({
+    ...card,
+    questionNumber: greenScoreCountQueries[index].data,
+    questionCountLoading: greenScoreCountQueries[index].isLoading,
+  }));
+  const areGreenScoreCountsReady = greenScoreCountQueries.every(
+    (query) => !query.isLoading,
   );
+  const displayedGreenScoreCards = areGreenScoreCountsReady
+    ? greenScoreCardsWithCounts.sort(
+        (first, second) =>
+          (second.questionNumber ?? -1) - (first.questionNumber ?? -1),
+      )
+    : greenScoreCardsWithCounts;
 
   return (
     <React.Suspense fallback={<Loader />}>
@@ -187,9 +220,13 @@ export default function GreenScore() {
                 gap: { xs: 1.5, sm: 2 },
               }}
             >
-              {sortedGreenScoreCards.map((props) => (
-                <SmallQuestionCard key={props.title} {...props} />
-              ))}
+              {areGreenScoreCountsReady
+                ? displayedGreenScoreCards.map((props) => (
+                    <SmallQuestionCard key={props.title} {...props} />
+                  ))
+                : greenScoreCards.map(({ title }) => (
+                    <GreenScoreCardSkeleton key={title} />
+                  ))}
             </Box>
           </Box>
 


### PR DESCRIPTION
## Summary
- modernize the Green-Score page to match the home-page visual system
- add localized explanations for label and category questions
- make country selection part of the Categories header
- show explicit question counts and sort labels and categories by unanswered-question count

## Validation
- yarn build
- targeted Prettier and ESLint checks