### PR TITLE
chore: clean up Vite migration leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,7 @@ yarn countries
 
 Generates the JSON file `src/assets/countries.json` which contains all the countries available on OFF taxonomy. Data are obtained from static.openfoodfacts.org
 
-#### Update the Taxonomy auto-complete file
-
-```
-node update-taxonomy-suggestions.js
-```
-
-Fetch categories and labels taxonomy from Open Food Facts static files, and generate JSON files used by the `Autocomplete` fields.
+Taxonomy autocomplete suggestions are fetched from Open Food Facts at runtime; no local update command is required.
 
 #### Maintenance - How to define a dashboard
 
@@ -146,7 +140,7 @@ You can also help by improving [translation in your language](https://translate.
 
 ## 👩‍⚖️ Licence
 
-- See [LICENSE.md](./LICENSE.md)
+- See [LICENSE](./LICENSE)
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ yarn countries
 
 Generates the JSON file `src/assets/countries.json` which contains all the countries available on OFF taxonomy. Data are obtained from static.openfoodfacts.org
 
-Taxonomy autocomplete suggestions are fetched from Open Food Facts at runtime; no local update command is required.
-
 #### Maintenance - How to define a dashboard
 
 Go to `src/pages/logosValidator/dashboardDefinition.ts`. You have two objects to edit:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  ignore = "node ignore_build.js"
+  command = "yarn build"
+  publish = "dist"
 
 [[redirects]]
   from = "/*"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "@types/node": "^26.4.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.7",
-    "@typescript-eslint/eslint-plugin": "^8.70.0",
-    "@typescript-eslint/parser": "^8.70.0",
     "@vitejs/plugin-react": "^6.1.1",
     "eslint": "^10.10.0",
     "eslint-plugin-react": "^7.37.5",
@@ -57,29 +55,10 @@
     "prettier": "prettier --write .",
     "countries": "node update-countries.js",
     "nutriments": "node update-nutriments.js",
-    "test": "react-scripts test",
     "deploy": "bash deploy.sh",
     "lint": "prettier --check . && eslint .",
     "prepare": "husky",
     "knip": "knip"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
   },
   "packageManager": "yarn@4.18.0",
   "resolutions": {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,7 +1643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.70.0, @typescript-eslint/eslint-plugin@npm:^8.70.0":
+"@typescript-eslint/eslint-plugin@npm:8.70.0":
   version: 8.70.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.70.0"
   dependencies:
@@ -1663,7 +1663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.70.0, @typescript-eslint/parser@npm:^8.70.0":
+"@typescript-eslint/parser@npm:8.70.0":
   version: 8.70.0
   resolution: "@typescript-eslint/parser@npm:8.70.0"
   dependencies:
@@ -3401,8 +3401,6 @@ __metadata:
     "@types/node": "npm:^26.4.1"
     "@types/react": "npm:^19.2.18"
     "@types/react-dom": "npm:^19.2.7"
-    "@typescript-eslint/eslint-plugin": "npm:^8.70.0"
-    "@typescript-eslint/parser": "npm:^8.70.0"
     "@vitejs/plugin-react": "npm:^6.1.1"
     axios: "npm:^1.20.0"
     eslint: "npm:^10.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,17 +647,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/retry@npm:^0.4.0":
+"@humanwhocodes/retry@npm:^0.4.0, @humanwhocodes/retry@npm:^0.4.2":
   version: 0.4.3
   resolution: "@humanwhocodes/retry@npm:0.4.3"
   checksum: 10/0b32cfd362bea7a30fbf80bb38dcaf77fee9c2cae477ee80b460871d03590110ac9c77d654f04ec5beaf71b6f6a89851bdf6c1e34ccdf2f686bd86fcd97d9e61
-  languageName: node
-  linkType: hard
-
-"@humanwhocodes/retry@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "@humanwhocodes/retry@npm:0.4.2"
-  checksum: 10/8910c4cdf8d46ce406e6f0cb4407ff6cfef70b15039bd5713cc059f32e02fe5119d833cfe2ebc5f522eae42fdd453b6d88f3fa7a1d8c4275aaad6eb3d3e9b117
   languageName: node
   linkType: hard
 
@@ -4751,14 +4744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "picomatch@npm:4.0.5"
-  checksum: 10/8bad770af9dcdb7f94ad1a893adcbe08a97d75a18872f8fed37161d3124217471c402b3929f051532f795f4ff2e53dcebb1644df4c1a5f3a9c476fef3b9f8c51
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.7":
+"picomatch@npm:^4.0.4, picomatch@npm:^4.0.5, picomatch@npm:^4.0.7":
   version: 4.0.7
   resolution: "picomatch@npm:4.0.7"
   checksum: 10/66e1df34bc39c72fa3756be4069f7887ea3e35e94bba1c3f6167763007698cb04b8a0a365161d186fda6e9571a2d3efb606b2966eb6a7dea6252911224dc2f48


### PR DESCRIPTION
## Summary
- remove obsolete Create React App test and ESLint configuration
- remove unused direct TypeScript ESLint dependencies and Jest setup
- configure Netlify to build and publish the Vite `dist` directory
- update stale README instructions and license link

## Validation
- `yarn lint`
- `yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup guidance to clarify that taxonomy autocomplete suggestions are retrieved at runtime.
  - Removed instructions for manually generating taxonomy suggestion files.
  - Updated the license link in the documentation.

- **Deployment**
  - Updated hosting configuration to build and publish the application’s distribution output.

- **Chores**
  - Removed obsolete testing and linting configuration from the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->